### PR TITLE
Add get-acceptance-status.py and accept-submissions.py

### DIFF
--- a/iclr2017/process/commentProcess.js
+++ b/iclr2017/process/commentProcess.js
@@ -2,8 +2,8 @@ function(){
     console.log('comment process initiated')
     var or3client = lib.or3client;
 
-    var list = note.invitation.replace(/_/g,' ').split('/');
-    list.splice(list.indexOf('-',1));
+    var list = note.invitation.replace(/_/g, ' ').split('/');
+    list.splice(list.indexOf('-', 1));
     var conference = list.join(' ')
 
     var getAuthorEmails = function(origNote){
@@ -14,92 +14,121 @@ function(){
       var author_mail = {
         "groups": origNoteAuthors,
         "subject": "Comment on your submission to ICLR 2017: \"" + origNote.content.title + "\".",
-        "message": "Your submission to "+ conference +" has received a comment.\n\nTitle: "+note.content.title+"\n\nComment: "+note.content.comment+"\n\nTo view the comment, click here: "+baseUrl+"/forum?id=" + note.forum
+        "message": "Your submission to " + conference + " has received a comment.\n\nTitle: " + note.content.title + "\n\nComment: " + note.content.comment + "\n\nTo view the comment, click here: " + baseUrl + "/forum?id=" + note.forum
       };
-      return or3client.or3request( or3client.mailUrl, author_mail, 'POST', token );
+      return or3client.or3request(or3client.mailUrl, author_mail, 'POST', token);
     };
 
     var getReviewerEmails = function(origNote){
       console.log('get reviewer emails initiated');
       var origNoteNumber = origNote.number;
-      return or3client.or3request(or3client.grpUrl+'?id=ICLR.cc/2017/conference/paper'+origNoteNumber+'/reviewers',{},'GET',token)
-      .then(result=>{
+      return or3client.or3request(or3client.grpUrl + '?id=ICLR.cc/2017/conference/paper' + origNoteNumber + '/reviewers', {}, 'GET', token)
+      .then(result => {
         var reviewers = result.groups[0].members;
-        console.log('reviewers before filter',reviewers);
+        console.log('reviewers before filter: ' + reviewers);
         var signatureIdx = reviewers.indexOf(note.signatures[0]);
-        if(signatureIdx>-1){
-          reviewers.splice(signatureIdx,1);
+        if (signatureIdx > -1){
+          reviewers.splice(signatureIdx, 1);
         };
 
         console.log('reviewers after filter',reviewers);
         var reviewer_mail = {
           "groups": reviewers,
           "subject": "Comment posted to your assigned paper: \"" + origNote.content.title + "\"",
-          "message": "A submission to "+ conference+", for which you are an official reviewer, has received a comment. \n\nTitle: "+note.content.title+"\n\nComment: "+note.content.comment+"\n\nTo view the comment, click here: "+baseUrl+"/forum?id=" + note.forum
+          "message": "A submission to " + conference + ", for which you are an official reviewer, has received a comment. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.comment + "\n\nTo view the comment, click here: " + baseUrl + "/forum?id=" + note.forum
         };
-        return or3client.or3request( or3client.mailUrl, reviewer_mail, 'POST', token );
+        return or3client.or3request(or3client.mailUrl, reviewer_mail, 'POST', token);
       })
     };
 
     var getAreachairEmails = function(origNote){
       console.log('get AC emails initiated');
       var origNoteNumber = origNote.number;
-      return or3client.or3request(or3client.grpUrl+'?id=ICLR.cc/2017/conference/paper'+origNoteNumber+'/areachairs',{},'GET',token)
-      .then(result=>{
+      return or3client.or3request(or3client.grpUrl + '?id=ICLR.cc/2017/conference/paper' + origNoteNumber + '/areachairs', {}, 'GET', token)
+      .then(result => {
         var areachairs = result.groups[0].members;
         var signatureIdx = areachairs.indexOf(note.signatures[0]);
-        console.log('areachairs before filter:',areachairs);
-        if(signatureIdx>-1){
-          areachairs.splice(signatureIdx,1);
+        console.log('areachairs before filter: ' + areachairs);
+        if (signatureIdx > -1){
+          areachairs.splice(signatureIdx, 1);
         };
-        console.log('areachairs after filter:',areachairs);
+        console.log('areachairs after filter: ' + areachairs);
         var areachair_mail = {
           "groups": areachairs,
           "subject": "Comment posted to your assigned paper: \"" + origNote.content.title + "\"",
-          "message": "A submission to "+ conference+", for which you are an official area chair, has received a comment. \n\nTitle: "+note.content.title+"\n\nComment: "+note.content.comment+"\n\nTo view the comment, click here: "+baseUrl+"/forum?id=" + note.forum
+          "message": "A submission to " + conference + ", for which you are an official area chair, has received a comment. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.comment + "\n\nTo view the comment, click here: " + baseUrl + "/forum?id=" + note.forum
         };
-        return or3client.or3request( or3client.mailUrl, areachair_mail, 'POST', token );
+        return or3client.or3request(or3client.mailUrl, areachair_mail, 'POST', token);
       })
     };
 
     var getPCEmails = function(origNote){
       console.log('get PC emails initiated');
-      return or3client.or3request(or3client.grpUrl+'?id=ICLR.cc/2017/pcs',{},'GET',token)
-      .then(result=>{
+      return or3client.or3request(or3client.grpUrl + '?id=ICLR.cc/2017/pcs', {}, 'GET', token)
+      .then(result => {
         var pcs = result.groups[0].members;
+
+        console.log('pcs before filter: ' + pcs);
+
+        var workshopIdx = pcs.indexOf('ICLR.cc/2017/workshop');
+        if (workshopIdx > -1){
+          pcs.splice(workshopIdx, 1);
+        }
+        var conferenceIdx = pcs.indexOf('ICLR.cc/2017/conference');
+        if (conferenceIdx > -1){
+          pcs.splice(conferenceIdx, 1);
+        }
+
         var signatureIdx = pcs.indexOf(note.signatures[0]);
-        console.log('pcs before filter:',pcs);
-        if(signatureIdx>-1){
-          pcs.splice(signatureIdx,1);
-        };
-        console.log('pcs after filter:',pcs);
+        if (signatureIdx > -1){
+          pcs.splice(signatureIdx, 1);
+        }
+
+        //if any member of the PCs is an author, remove that PC from email recipients
+        for (var i = 0; i < origNote.content.authorids.length; i++){
+          var currentAuth = origNote.content.authorids[i];
+
+          var pcIdx = pcs.indexOf(currentAuth);
+
+          //workaround for hugo
+          if (currentAuth == 'hugo.larochelle@usherbrooke.ca'){
+            pcIdx = pcs.indexOf('hugo@twitter.com');
+          }
+
+          if (pcIdx > -1){
+            pcs.splice(pcIdx, 1);
+            console.log('Program chair ' + currentAuth + ' found in authorids. Removing them from email recipients list');
+          }
+        }
+        console.log('pcs after filter: ' + pcs);
+
         var pc_mail = {
           "groups": pcs,
           "subject": "Private comment posted to a paper: \"" + origNote.content.title + "\"",
-          "message": "A submission to "+ conference+" has received a private comment. \n\nTitle: "+note.content.title+"\n\nComment: "+note.content.comment+"\n\nTo view the comment, click here: "+baseUrl+"/forum?id=" + note.forum
+          "message": "A submission to " + conference + " has received a private comment. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.comment + "\n\nTo view the comment, click here: " + baseUrl + "/forum?id=" + note.forum
         };
         return or3client.or3request( or3client.mailUrl, pc_mail, 'POST', token );
       })
     };
 
     var getCommentEmails = function(replytoNoteSignatures, origNote){
-      console.log('replytoNoteSignatures before filter:',replytoNoteSignatures);
+      console.log('replytoNoteSignatures before filter: ' + replytoNoteSignatures);
 
-      if(note.readers.indexOf('everyone') == -1){
-        replytoNoteSignatures=[];
+      if (note.readers.indexOf('everyone') == -1){
+        replytoNoteSignatures = [];
       };
-      console.log('replytoNoteSignatures after filter:',replytoNoteSignatures);
+      console.log('replytoNoteSignatures after filter: '+replytoNoteSignatures);
       var comment_mail = {
         "groups": replytoNoteSignatures,
         "subject":"Your post has received a comment, paper: \"" + origNote.content.title + "\"",
-        "message": "One of your posts has received a comment.\n\nTitle: "+note.content.title+"\n\nComment: "+note.content.comment+"\n\nTo view the comment, click here: "+baseUrl+"/forum?id=" + note.forum
+        "message": "One of your posts has received a comment.\n\nTitle: " + note.content.title + "\n\nComment: " + note.content.comment + "\n\nTo view the comment, click here: " + baseUrl + "/forum?id=" + note.forum
       };
-      return or3client.or3request( or3client.mailUrl, comment_mail, 'POST', token );
+      return or3client.or3request(or3client.mailUrl, comment_mail, 'POST', token);
     };
 
     console.log('functions defined')
-    var origNoteP = or3client.or3request(or3client.notesUrl+'?id='+note.forum, {}, 'GET', token);
-    var replytoNoteP = note.replyto ? or3client.or3request(or3client.notesUrl+'?id='+note.replyto,{},'GET',token) : null;
+    var origNoteP = or3client.or3request(or3client.notesUrl + '?id=' + note.forum, {}, 'GET', token);
+    var replytoNoteP = note.replyto ? or3client.or3request(or3client.notesUrl + '?id=' + note.replyto, {}, 'GET', token) : null;
     console.log('promises created')
     Promise.all([
       origNoteP,
@@ -113,43 +142,38 @@ function(){
       var replytoNoteReaders = replytoNote ? replytoNote.readers : null;
       var replytoNoteSignatures = replytoNote ? replytoNote.signatures : null;
 
-      console.log('replytoNote',replytoNote);
-      console.log('replytoNoteReaders',replytoNoteReaders);
-      console.log('replytoNoteSignatures',replytoNoteSignatures);
       var promises = [];
-      console.log('note',note)
-      console.log('note.readers',note.readers)
-      var visibleToEveryone = note.readers.indexOf('everyone')>-1 ? true : false;
-      console.log('visibleToEveryone',visibleToEveryone);
-      var visibleToReviewers = note.readers.indexOf('ICLR.cc/2017/conference/reviewers_and_ACS_and_organizers')>-1 ? true : false;
-      var visibleToAreachairs = note.readers.indexOf('ICLR.cc/2017/conference/ACs_and_organizers')>-1 ? true : false;
-      var visibleToPCs = note.readers.indexOf('ICLR.cc/2017/conference/organizers')>-1 ? true : false;
+      var visibleToEveryone = note.readers.indexOf('everyone') > -1 ? true : false;
 
-      if(visibleToEveryone){
+      var visibleToReviewers = note.readers.indexOf('ICLR.cc/2017/conference/reviewers_and_ACS_and_organizers') > -1 ? true : false;
+      var visibleToAreachairs = note.readers.indexOf('ICLR.cc/2017/conference/ACs_and_organizers') > -1 ? true : false;
+      var visibleToPCs = note.readers.indexOf('ICLR.cc/2017/conference/organizers') > -1 ? true : false;
+
+      if (visibleToEveryone){
         var authorMailP = getAuthorEmails(origNote);
         promises.push(authorMailP);
       };
 
-      if(visibleToEveryone || visibleToReviewers){
+      if (visibleToEveryone || visibleToReviewers){
         var reviewerMailP = getReviewerEmails(origNote);
         promises.push(reviewerMailP);
       };
 
-      if(visibleToEveryone || visibleToReviewers || visibleToAreachairs){
+      if (visibleToEveryone || visibleToReviewers || visibleToAreachairs){
         var areachairMailP = getAreachairEmails(origNote);
         promises.push(areachairMailP);
       };
 
-      if(visibleToReviewers || visibleToAreachairs || visibleToPCs){
+      if (visibleToReviewers || visibleToAreachairs || visibleToPCs){
         var pcMailP = getPCEmails(origNote);
         promises.push(pcMailP);
       }
 
       var rootComment = note.forum == note.replyto;
-      var anonComment = replytoNoteSignatures.indexOf('(anonymous)')>-1 ? true : false;
-      var selfComment = replytoNoteSignatures.indexOf(note.signatures[0])>-1 ? true : false;
+      var anonComment = replytoNoteSignatures.indexOf('(anonymous)') > -1 ? true : false;
+      var selfComment = replytoNoteSignatures.indexOf(note.signatures[0]) > -1 ? true : false;
 
-      if(!rootComment && !anonComment && !selfComment) {
+      if (!rootComment && !anonComment && !selfComment) {
         var commentMailP = getCommentEmails(replytoNoteSignatures, origNote);
         promises.push(commentMailP);
       };

--- a/iclr2017/python/get-stats.py
+++ b/iclr2017/python/get-stats.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+
+"""
+Get the amount of replies per paper for reviewers/areachairs. It doesn't count the reviews/meta-reviews
+
+"""
+
+## Import statements
+import argparse
+import csv
+import sys
+import openreview
+import requests
+
+## Handle the arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', '--type', help="reviewer or areachair, by default reviewer")
+parser.add_argument('--baseurl', help="base URL")
+parser.add_argument('--username')
+parser.add_argument('--password')
+
+args = parser.parse_args()
+
+## Initialize the client library with username and password
+if args.username!=None and args.password!=None:
+    client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+else:
+    client = openreview.Client(baseurl=args.baseurl)
+
+
+replies_by_author = {}
+submissions = {}
+
+iclrsubs = client.get_notes(invitation='ICLR.cc/2017/conference/-/submission')
+for s in iclrsubs:
+    submissions[s.id] = s
+
+headers = {'User-Agent': 'test-create-script', 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + client.token}
+
+def get_replies_by_author(paper_number, author):
+
+    if author not in replies_by_author:
+        replies_by_author[author] = {}
+
+    replies = replies_by_author[author]
+
+    if paper_number in replies:
+        return replies[paper_number]
+    else:
+        notes = client.get_notes(tauthor = author)
+        for n in notes:
+            submission = submissions.get(n.forum, None)
+            invitation = str(n.invitation)
+            if submission and not invitation.endswith('official/review') and not invitation.endswith('meta/review'):
+                if submission.number not in replies_by_author[author]:
+                    replies_by_author[author][submission.number] = set()
+                replies_by_author[author][submission.number].add(n.id)
+        return replies_by_author[author].get(paper_number, [])
+
+
+def get_stats(anonGroup, currentGroup):
+
+    anon_reviewers = requests.get(client.baseurl+'/groups?id=ICLR.cc/2017/conference/paper.*/' + anonGroup + '.*', headers = headers)
+    current_reviewers = requests.get(client.baseurl+'/groups?id=ICLR.cc/2017/conference/paper.*/' + currentGroup, headers = headers)
+
+    reviewers = {}
+    reviewers_by_paper = {}
+
+    for r in anon_reviewers.json():
+        reviewer_id = r['id']
+        members = r['members']
+        if members:
+            reviewers[reviewer_id] = members[0]
+
+    for r in current_reviewers.json():
+        reviewer_id = r['id']
+        members = r['members']
+        if members:
+            paper_number = int(reviewer_id.split('paper')[1].split('/' + currentGroup)[0])
+            if paper_number not in reviewers_by_paper:
+                reviewers_by_paper[paper_number] = {}
+
+            for m in members:
+                reviewer_name = reviewers.get(m, m)
+                reviewers_by_paper[paper_number][reviewer_name] = get_replies_by_author(paper_number, reviewer_name)
+
+    return reviewers_by_paper
+
+anonGroup = 'AnonReviewer'
+currentGroup = 'reviewers'
+
+if args.type != None and args.type == 'areachair':
+    anonGroup = 'areachair'
+    currentGroup = 'areachairs'
+
+data = get_stats(anonGroup, currentGroup)
+
+for paper_number, author_data in data.iteritems():
+
+    for author, replies in author_data.iteritems():
+
+        print str(paper_number) + ', ' + author.encode('utf-8') + ', ' + str(len(replies))
+
+
+
+
+
+

--- a/iclr2017/webfield/areachair_webfield.html
+++ b/iclr2017/webfield/areachair_webfield.html
@@ -90,11 +90,12 @@
           if(metaReview){
             $paperStatus.append($('<span>',{html:"<b>Your recommendation:</b> "+ metaReview.content.recommendation}), '\n');
           } else {
-            var $metareviewLink = $('<div>', {class: 'link', id:'metareview_link'+paperNum, text: "Enter "+view.prettyInvitationId(metaReviewInv.id)});
-            $(document).on('click', '#metareview_link'+paperNum, function(){
+            var $metareviewLink = $('<div>', { class: 'link', id: 'metareview_link' + paperNum, text: "Enter " + view.prettyInvitationId(metaReviewInv.id) });
+            $metareviewLink.on('click', function(){
               pushForum(metaReviewInv.reply.forum, metaReviewInv.reply.replyto, metaReviewInv.id);
             });
-            $paperStatus.append($('<span>',{html:"Meta review incomplete: "+$metareviewLink.prop('outerHTML')}));
+
+            $paperStatus.append($('<span>', { text: "Meta review incomplete: " }).append($metareviewLink));
           }
 
           $paperStatus.append('\n');
@@ -110,12 +111,12 @@
 
             $paperStatus.append($('<span>',{html:htmlstring}));
           } else {
-            var $ratingLink = $('<div>', {class: 'link', id:'rating_link'+paperNum, text: "Enter "+view.prettyInvitationId(ratingInv.id)});
+            var $ratingLink = $('<div>', {class: 'link', id:'rating_link' + paperNum, text: "Enter " + view.prettyInvitationId(ratingInv.id)});
 
-            $(document).on('click', '#rating_link'+paperNum, function(){
+            $ratingLink.on('click', function(){
               pushForum(ratingInv.reply.forum, ratingInv.reply.replyto, ratingInv.id);
             });
-            $paperStatus.append($('<span>',{html:"Reviewer ratings incomplete: "+$ratingLink.prop('outerHTML')}));
+            $paperStatus.append($('<span>', { text: "Reviewer ratings incomplete: " }).append($ratingLink));
           }
 
           return $paperStatus

--- a/uai2017/python/superuser-init.py
+++ b/uai2017/python/superuser-init.py
@@ -197,7 +197,7 @@ if client.user['id'].lower()=='openreview.net':
             'values-regex': '~.*'
         },
         'writers': {
-            'values-regex': '~.*'
+            'value-copied': '{content.authorids}'
         },
         'content': {
             'title': {


### PR DESCRIPTION
When all reviews are in, the area chair adds their own recommendation for Poster, Oral, Rejection or Workshop. The get-acceptance-status.py script creates a csv file for all papers with their meta/review recommendation and comments and final acceptance result (when available).  
The final acceptance results in the outputted file can be edited by the PC.  
Then use accept-submissions.py to read in this adjusted csv file and post an acceptance note for each paper with a newly added final result. 