### PR TITLE
Fix/invitation constructor api

### DIFF
--- a/cvpr2017/python/superuser-init.py
+++ b/cvpr2017/python/superuser-init.py
@@ -113,8 +113,7 @@ if client.user['id'].lower()=='openreview.net':
     invitations = []
 
     ## Create the submission invitation, form, and add it to the list of invitations to post
-    submission_invitation = openreview.Invitation(CONFERENCE,
-        'Submission',
+    submission_invitation = openreview.Invitation(CONFERENCE+'/-/Submission',
         readers = ['everyone'],
         writers = [CONFERENCE],
         invitees = ['~'],

--- a/dblp/python/superuser-init.py
+++ b/dblp/python/superuser-init.py
@@ -249,8 +249,7 @@ if openreview.user['id'].lower() == 'openreview.net':
 
         }
     }
-    submission_invitation = Invitation('DBLP.org',
-                                       'paper',
+    submission_invitation = Invitation('DBLP.org/-/paper',
                                        readers=['everyone'],
                                        writers=['DBLP.org/upload'],
                                        invitees=['DBLP.org/upload'],
@@ -264,7 +263,7 @@ if openreview.user['id'].lower() == 'openreview.net':
     revision_reply.pop('replyto')
     revision_reply['referent'] = None
 
-    revision_invitation = Invitation('DBLP.org','Add/Revision',
+    revision_invitation = Invitation('DBLP.org/-/Add/Revision',
         signatures = ['DBLP.org'],
         writers = ['DBLP.org/upload'],
         invitees = ['DBLP.org/upload'],

--- a/eccv2016/python/setup-invitations.py
+++ b/eccv2016/python/setup-invitations.py
@@ -32,8 +32,8 @@ submission_reply = {
     'description':'Your displayed identity associated with the above content.'
   },
   'writers': {'values-regex': '~.*'},
-  'readers': { 
-    'values': ['everyone'], 
+  'readers': {
+    'values': ['everyone'],
     'description': 'The users who will be allowed to read the above content.'
   },
   'content': {
@@ -78,7 +78,7 @@ submission_reply = {
   }
 }
 
-submission_invitation = Invitation('ECCV2016.org/BNMW','submission',
+submission_invitation = Invitation('ECCV2016.org/BNMW/-/submission',
 	readers=['everyone'],
 	writers=['ECCV2016.org/BNMW'],
 	invitees=['~'],
@@ -87,4 +87,4 @@ submission_invitation = Invitation('ECCV2016.org/BNMW','submission',
 	reply=submission_reply)
 
 openreview.post_invitation(submission_invitation)
-        
+

--- a/iclr2017/python/superuser-create-ratings.py
+++ b/iclr2017/python/superuser-create-ratings.py
@@ -49,9 +49,7 @@ for i in iclrsubs:
         'value':'Review Rating: '+i.content['title']
     }
 
-    ac_rating_invitation = openreview.Invitation(
-        'ICLR.cc/2017/conference',
-        'paper%s/AC/Review/Rating' % i.number,
+    ac_rating_invitation = openreview.Invitation('ICLR.cc/2017/conference/-/paper%s/AC/Review/Rating' % i.number,
         readers = ['ICLR.cc/2017/conference','ICLR.cc/2017/conference/paper%s/areachairs' % i.number],
         writers = ['ICLR.cc/2017/conference'],
         signatures = ['ICLR.cc/2017/conference'],
@@ -76,8 +74,7 @@ for i in iclrsubs:
     client.post_invitation(ac_rating_invitation)
 
     author_rating_invitation = openreview.Invitation(
-        'ICLR.cc/2017/conference',
-        'paper%s/Author/Review/Rating' % i.number,
+        'ICLR.cc/2017/conference/-/paper%s/Author/Review/Rating' % i.number,
         readers = ['ICLR.cc/2017/conference','ICLR.cc/2017/conference/paper%s/authors' % i.number],
         writers = ['ICLR.cc/2017/conference'],
         signatures = ['ICLR.cc/2017/conference'],

--- a/iclr2017/python/superuser-init.py
+++ b/iclr2017/python/superuser-init.py
@@ -279,8 +279,7 @@ if openreview.user['id'].lower()=='openreview.net':
 
     submission_reply=reply.copy()
 
-    submission_invitation = Invitation( 'ICLR.cc/2017/conference',
-        'submission',
+    submission_invitation = Invitation( 'ICLR.cc/2017/conference/-/submission',
         readers=['everyone'],
         writers=['ICLR.cc/2017/conference'],
         invitees=['~'],
@@ -319,8 +318,7 @@ if openreview.user['id'].lower()=='openreview.net':
         }
     }
 
-    reviewer_invitation = Invitation('ICLR.cc/2017/conference',
-        'reviewer_invitation',
+    reviewer_invitation = Invitation('ICLR.cc/2017/conference/-/reviewer_invitation',
         readers=['everyone'],
         writers=['ICLR.cc/2017/conference'],
         invitees=['everyone'],

--- a/iclr2017/python/superuser-workshop-init.py
+++ b/iclr2017/python/superuser-workshop-init.py
@@ -182,8 +182,7 @@ if client.user['id'].lower()=='openreview.net':
 
     submission_reply=reply.copy()
 
-    submission_invitation = openreview.Invitation( 'ICLR.cc/2017/workshop',
-        'submission',
+    submission_invitation = openreview.Invitation( 'ICLR.cc/2017/workshop/-/submission',
         readers=['everyone'],
         writers=['ICLR.cc/2017/workshop'],
         invitees=['~'],
@@ -222,8 +221,7 @@ if client.user['id'].lower()=='openreview.net':
         }
     }
 
-    reviewer_invitation = openreview.Invitation('ICLR.cc/2017/workshop',
-        'reviewer_invitation',
+    reviewer_invitation = openreview.Invitation('ICLR.cc/2017/workshop/-/reviewer_invitation',
         readers=['everyone'],
         writers=['ICLR.cc/2017/workshop'],
         invitees=['everyone'],

--- a/nips2016_DLSymposium/python/setup-invitations.py
+++ b/nips2016_DLSymposium/python/setup-invitations.py
@@ -78,12 +78,11 @@ recommendation_reply = {
         }
     }
 }
-recommendation_invitation = Invitation('NIPS.cc/2016/Deep_Learning_Symposium',
-    'recommendation', 
+recommendation_invitation = Invitation('NIPS.cc/2016/Deep_Learning_Symposium/-/recommendation',
     writers     = ['NIPS.cc/2016/Deep_Learning_Symposium'],
-    readers     = ['everyone'], 
-    invitees    = ['~'], 
-    reply       = recommendation_reply, 
+    readers     = ['everyone'],
+    invitees    = ['~'],
+    reply       = recommendation_reply,
     process     = '../process/recommendationProcess_nips_symposium2016.js',
     signatures  = ['NIPS.cc/2016/Deep_Learning_Symposium'])
 

--- a/nips2016_MLITS/python/setup-invitations.py
+++ b/nips2016_MLITS/python/setup-invitations.py
@@ -32,8 +32,8 @@ submission_reply = {
     'description':'Your displayed identity associated with the above content.'
   },
   'writers': {'values-regex': '~.*'},
-  'readers': { 
-    'values': ['everyone'], 
+  'readers': {
+    'values': ['everyone'],
     'description': 'The users who will be allowed to read the above content.'
   },
   'content': {
@@ -70,7 +70,7 @@ submission_reply = {
   }
 }
 
-submission_invitation = Invitation('NIPS.cc/2016/workshop/MLITS','submission',
+submission_invitation = Invitation('NIPS.cc/2016/workshop/MLITS/-/submission',
 	readers=['everyone'],
 	writers=['NIPS.cc/2016/workshop/MLITS'],
 	invitees=['~'],
@@ -80,4 +80,4 @@ submission_invitation = Invitation('NIPS.cc/2016/workshop/MLITS','submission',
 
 print 'posting invitation: '+submission_invitation.id
 openreview.post_invitation(submission_invitation)
-        
+

--- a/nips2016_NAMPI/python/superuser-init.py
+++ b/nips2016_NAMPI/python/superuser-init.py
@@ -41,10 +41,10 @@ def overwrite_allowed(groupid):
 print "overwrite allowed?",overwrite_allowed('NIPS.cc/2016/workshop')
 
 if openreview.user['id'].lower()=='openreview.net':
-    
+
     #########################
     ##    SETUP GROUPS     ##
-    ######################### 
+    #########################
 
     if overwrite_allowed('NIPS.cc/2016/workshop'):
         print 'workshop made'
@@ -55,13 +55,13 @@ if openreview.user['id'].lower()=='openreview.net':
             readers     = ['everyone'],
             signatures  = ['NIPS.cc/2016'])
         groups.append(nips2016_workshop)
-    
+
     if overwrite_allowed('NIPS.cc/2016/workshop/NAMPI'):
-        nips2016_workshop_NAMPI = Group('NIPS.cc/2016/workshop/NAMPI', 
-            signatories = ['NIPS.cc/2016/workshop/NAMPI'], 
+        nips2016_workshop_NAMPI = Group('NIPS.cc/2016/workshop/NAMPI',
+            signatories = ['NIPS.cc/2016/workshop/NAMPI'],
             writers     = ['NIPS.cc/2016/workshop','NIPS.cc/2016/workshop/NAMPI','NIPS.cc/2016/workshop/NAMPI/pcs'],
             members     = ['NIPS.cc/2016/workshop/NAMPI/pcs'],
-            readers     = ['everyone'], 
+            readers     = ['everyone'],
             web         = '../webfield/NAMPI-webfield.html',
             signatures  = ['NIPS.cc/2016/workshop'])
         groups.append(nips2016_workshop_NAMPI)
@@ -71,8 +71,8 @@ if openreview.user['id'].lower()=='openreview.net':
 
 
     if overwrite_allowed('NIPS.cc/2016/workshop/NAMPI/pcs'):
-        NAMPIprogramchairs = Group('NIPS.cc/2016/workshop/NAMPI/pcs', 
-            readers=['everyone'], 
+        NAMPIprogramchairs = Group('NIPS.cc/2016/workshop/NAMPI/pcs',
+            readers=['everyone'],
             writers=['NIPS.cc/2016/workshop/NAMPI','NIPS.cc/2016/workshop/NAMPI/pcs'],
             signatures=['NIPS.cc/2016/workshop/NAMPI'],
             signatories=['NIPS.cc/2016/workshop/NAMPI/pcs'],
@@ -81,8 +81,8 @@ if openreview.user['id'].lower()=='openreview.net':
 
 
     if overwrite_allowed('NIPS.cc/2016/workshop/NAMPI/reviewers-invited'):
-        NAMPIreviewersinvited = Group('NIPS.cc/2016/workshop/NAMPI/reviewers-invited', 
-            readers=['NIPS.cc/2016/workshop/NAMPI/pcs','NIPS.cc/2016/workshop/NAMPI','OpenReview.net'], 
+        NAMPIreviewersinvited = Group('NIPS.cc/2016/workshop/NAMPI/reviewers-invited',
+            readers=['NIPS.cc/2016/workshop/NAMPI/pcs','NIPS.cc/2016/workshop/NAMPI','OpenReview.net'],
             writers=['NIPS.cc/2016/workshop/NAMPI/pcs'],
             signatures=['NIPS.cc/2016/workshop/NAMPI/pcs'],
             signatories=['NIPS.cc/2016/workshop/NAMPI/reviewers-invited'],
@@ -90,8 +90,8 @@ if openreview.user['id'].lower()=='openreview.net':
         groups.append(NAMPIreviewersinvited)
 
     if overwrite_allowed('NIPS.cc/2016/workshop/NAMPI/reviewers-emailed'):
-        NAMPIreviewersemailed = Group('NIPS.cc/2016/workshop/NAMPI/reviewers-emailed', 
-            readers=['NIPS.cc/2016/workshop/NAMPI/pcs','NIPS.cc/2016/workshop/NAMPI'], 
+        NAMPIreviewersemailed = Group('NIPS.cc/2016/workshop/NAMPI/reviewers-emailed',
+            readers=['NIPS.cc/2016/workshop/NAMPI/pcs','NIPS.cc/2016/workshop/NAMPI'],
             writers=['NIPS.cc/2016/workshop/NAMPI/pcs'],
             signatures=['NIPS.cc/2016/workshop/NAMPI/pcs'],
             signatories=['NIPS.cc/2016/workshop/NAMPI/reviewers-emailed'],
@@ -100,7 +100,7 @@ if openreview.user['id'].lower()=='openreview.net':
 
 
     if overwrite_allowed('NIPS.cc/2016/workshop/NAMPI/reviewers'):
-        NAMPIreviewers = Group('NIPS.cc/2016/workshop/NAMPI/reviewers', 
+        NAMPIreviewers = Group('NIPS.cc/2016/workshop/NAMPI/reviewers',
             readers=['everyone'],
             writers=['NIPS.cc/2016/workshop/NAMPI','NIPS.cc/2016/workshop/NAMPI/pcs'],
             signatures=['NIPS.cc/2016/workshop/NAMPI'],
@@ -132,7 +132,7 @@ if openreview.user['id'].lower()=='openreview.net':
 
     #########################
     ##  SETUP INVITATIONS  ##
-    ######################### 
+    #########################
 
 
     ## Create the submission invitation
@@ -221,24 +221,22 @@ if openreview.user['id'].lower()=='openreview.net':
     submission_reply=reply.copy()
     submission_reply['referenti']=['NIPS.cc/2016/workshop/NAMPI/-/reference']
 
-    submission_invitation = Invitation( 'NIPS.cc/2016/workshop/NAMPI',
-        'submission', 
-        readers=['everyone'], 
+    submission_invitation = Invitation( 'NIPS.cc/2016/workshop/NAMPI/-/submission',
+        readers=['everyone'],
         writers=['NIPS.cc/2016/workshop/NAMPI'],
-        invitees=['~'], 
-        signatures=['NIPS.cc/2016/workshop/NAMPI/pcs'], 
+        invitees=['~'],
+        signatures=['NIPS.cc/2016/workshop/NAMPI/pcs'],
         reply=submission_reply,
         duedate=1477871999000, #Duedate set to OCT 30 23:59:59 GMT
         process='../process/submissionProcess_NAMPI.js')
 
     reference_reply=reply.copy()
 
-    reference_invitation = Invitation('NIPS.cc/2016/workshop/NAMPI',
-        'reference',
-        readers=['everyone'], 
+    reference_invitation = Invitation('NIPS.cc/2016/workshop/NAMPI/-/reference',
+        readers=['everyone'],
         writers=['NIPS.cc/2016/workshop/NAMPI'],
-        invitees=['~'], 
-        signatures=['NIPS.cc/2016/workshop/NAMPI/pcs'], 
+        invitees=['~'],
+        signatures=['NIPS.cc/2016/workshop/NAMPI/pcs'],
         reply=reference_reply)
 
 
@@ -272,14 +270,13 @@ if openreview.user['id'].lower()=='openreview.net':
         }
     }
 
-    reviewer_invitation = Invitation('NIPS.cc/2016/workshop/NAMPI',
-        'reviewer_invitation', 
+    reviewer_invitation = Invitation('NIPS.cc/2016/workshop/NAMPI/-/reviewer_invitation',
         readers=['everyone'],
-        writers=['NIPS.cc/2016/workshop/NAMPI'], 
+        writers=['NIPS.cc/2016/workshop/NAMPI'],
         invitees=['everyone'],
-        signatures=['NIPS.cc/2016/workshop/NAMPI'], 
-        reply=reviewer_invitation_reply, 
-        process='../process/responseInvitationProcess.js', 
+        signatures=['NIPS.cc/2016/workshop/NAMPI'],
+        reply=reviewer_invitation_reply,
+        process='../process/responseInvitationProcess.js',
         web='../webfield/NAMPI-invitation-webfield.html')
 
     invitations = [submission_invitation, reference_invitation, reviewer_invitation]

--- a/rss2017/python/superuser-init.py
+++ b/rss2017/python/superuser-init.py
@@ -244,8 +244,7 @@ if client.user['id'].lower()=='openreview.net':
 
     call(["node", "../../scripts/processToFile.js", "../process/submissionProcess.template", "../process", "Poster"])
     call(["node", "../../scripts/processToFile.js", "../process/submissionProcess.template", "../process", "Proceedings"])
-    proceeding_invitation = openreview.Invitation(PROCEEDINGS,
-        'Submission',
+    proceeding_invitation = openreview.Invitation(PROCEEDINGS+'/-/Submission',
         readers = ['everyone'],
         writers = [PROCEEDINGS],
         invitees = ['~'],
@@ -255,8 +254,7 @@ if client.user['id'].lower()=='openreview.net':
     proceeding_invitation.reply = reply.copy()
 
 
-    poster_invitation = openreview.Invitation(POSTER,
-        'Submission',
+    poster_invitation = openreview.Invitation(POSTER+'/-/Submission',
         readers = ['everyone'],
         writers = [POSTER],
         invitees = ['~'],

--- a/uai2017/python/metadata-init.py
+++ b/uai2017/python/metadata-init.py
@@ -46,7 +46,7 @@ metadata_reply = {
     'content': {}
 }
 
-paper_metadata_invitation = openreview.Invitation(CONFERENCE,'Paper/Metadata',
+paper_metadata_invitation = openreview.Invitation(CONFERENCE+'/-/Paper/Metadata',
                                            writers=['OpenReview.net'],
                                            readers=['OpenReview.net'],
                                            invitees=['OpenReview.net'],
@@ -56,7 +56,7 @@ client.post_invitation(paper_metadata_invitation)
 
 
 #Create the reviewer metadata invitation
-reviewer_metadata_invitation = openreview.Invitation(CONFERENCE,'Reviewer/Metadata',
+reviewer_metadata_invitation = openreview.Invitation(CONFERENCE+'/-/Reviewer/Metadata',
                                            writers=['OpenReview.net'],
                                            readers=['OpenReview.net'],
                                            invitees=['OpenReview.net'],
@@ -65,7 +65,7 @@ reviewer_metadata_invitation = openreview.Invitation(CONFERENCE,'Reviewer/Metada
 client.post_invitation(reviewer_metadata_invitation)
 
 #Create the user metadata invitation
-areachair_metadata_invitation = openreview.Invitation(CONFERENCE,'Area_Chair/Metadata',
+areachair_metadata_invitation = openreview.Invitation(CONFERENCE+'/-/Area_Chair/Metadata',
                                            writers=['OpenReview.net'],
                                            readers=['OpenReview.net'],
                                            invitees=['OpenReview.net'],

--- a/uai2017/python/superuser-init.py
+++ b/uai2017/python/superuser-init.py
@@ -185,8 +185,7 @@ if client.user['id'].lower()=='openreview.net':
     invitations = []
 
     ## Create the submission invitation, form, and add it to the list of invitations to post
-    submission_invitation = openreview.Invitation(CONFERENCE,
-        'submission',
+    submission_invitation = openreview.Invitation(CONFERENCE+'/-/submission',
         readers = ['everyone'],
         writers = [CONFERENCE],
         invitees = ['~'],
@@ -270,8 +269,7 @@ if client.user['id'].lower()=='openreview.net':
 
     invitations.append(submission_invitation)
 
-    blind_submission_invitation = openreview.Invitation(CONFERENCE,
-        'blind-submission',
+    blind_submission_invitation = openreview.Invitation(CONFERENCE+'/-/blind-submission',
         readers = ['everyone'],
         writers = [CONFERENCE],
         invitees = ['~'],
@@ -311,8 +309,7 @@ if client.user['id'].lower()=='openreview.net':
     invitations.append(blind_submission_invitation)
 
     ## Create Senior_Program_Committee recruitment invitation/form, and add it to the list of invitations to post
-    spc_invitation = openreview.Invitation(CONFERENCE,
-        'spc_invitation',
+    spc_invitation = openreview.Invitation(CONFERENCE+'/-/spc_invitation',
         readers=['everyone'],
         writers=[CONFERENCE],
         invitees=[SPC + '/invited'],
@@ -352,7 +349,7 @@ if client.user['id'].lower()=='openreview.net':
     invitations.append(spc_invitation)
 
     ## Create Program_Committee recruitment invitation/form, and add it to the list of invitations to post
-    pc_invitation = openreview.Invitation('auai.org/UAI/2017', 'pc_invitation',
+    pc_invitation = openreview.Invitation(CONFERENCE+'/-/pc_invitation',
         readers = ['everyone'],
         writers = [CONFERENCE],
         invitees = [PC + '/invited'],
@@ -393,7 +390,7 @@ if client.user['id'].lower()=='openreview.net':
 
 
     ## Create Senior_Program_Committee registration invitation, and add it to the list of invitations to post
-    spc_registration = openreview.Invitation(CONFERENCE, 'spc_registration',
+    spc_registration = openreview.Invitation(CONFERENCE+'/-/spc_registration',
         readers = [CONFERENCE, COCHAIRS],
         writers = [CONFERENCE],
         invitees = ['OpenReview.net'],
@@ -431,7 +428,7 @@ if client.user['id'].lower()=='openreview.net':
 
 
     ## Create Senior_Program_Committee registration invitation, and add it to the list of invitations to post
-    pc_registration = openreview.Invitation(CONFERENCE, 'pc_registration',
+    pc_registration = openreview.Invitation(CONFERENCE+'/-/pc_registration',
         readers = [CONFERENCE, COCHAIRS],
         writers = [CONFERENCE],
         invitees = ['OpenReview.net'],
@@ -486,8 +483,7 @@ if client.user['id'].lower()=='openreview.net':
         'content': {} #content is blank; this allows for ANYTHING to be placed in the content field.
         #we'll want to change this later one we know what the format will be.
     }
-    paper_metadata_invitation = openreview.Invitation(CONFERENCE,
-        'Paper/Metadata',
+    paper_metadata_invitation = openreview.Invitation(CONFERENCE+'/-/Paper/Metadata',
         writers = ['OpenReview.net'],
         readers = ['OpenReview.net',CONFERENCE],
         invitees = ['OpenReview.net'],
@@ -515,8 +511,7 @@ if client.user['id'].lower()=='openreview.net':
         'content': {} #Content is blank. See above.
     }
 
-    reviewer_metadata_invitation = openreview.Invitation(CONFERENCE,
-        'Reviewer/Metadata',
+    reviewer_metadata_invitation = openreview.Invitation(CONFERENCE+'/-/Reviewer/Metadata',
         writers=['OpenReview.net'],
         readers=['OpenReview.net', CONFERENCE],
         invitees=['OpenReview.net'],
@@ -526,8 +521,7 @@ if client.user['id'].lower()=='openreview.net':
     invitations.append(reviewer_metadata_invitation)
 
 
-    bid_tag_invitation = openreview.Invitation(CONFERENCE,
-        'Add/Bid',
+    bid_tag_invitation = openreview.Invitation(CONFERENCE+'/-/Add/Bid',
         readers=['everyone'],
         writers=[CONFERENCE],
         invitees=[],


### PR DESCRIPTION
formerly, the openreview.Invitation() constructor accepted two required arguments: one for the "owner" and one for the invitation name. Now it only accepts an Id, just like openreview.Group and openreview.Note