### PR TITLE
add conflict detection to assignment scripts

### DIFF
--- a/uai2017/python/assign-program-committee.py
+++ b/uai2017/python/assign-program-committee.py
@@ -17,7 +17,7 @@ from uaidata import *
 # Argument handling and initialization
 # .............................................................................
 parser = argparse.ArgumentParser()
-parser.add_argument('-a','--assignments', help="either (1) a csv file containing reviewer assignments or (2) a string of the format '<openreview_id>,<paper#>' e.g. '~Alan_Turing1,23'")
+parser.add_argument('-a','--assignments', help="either (1) a csv file containing reviewer assignments or (2) a string of the format '<openreview_id>,<paper#>' e.g. '~Alan_Turing1,23'", required=True)
 parser.add_argument('-o','--overwrite', help="if true, erases existing assignments before assigning")
 parser.add_argument('--baseurl', help="base url")
 parser.add_argument('--username')
@@ -49,7 +49,25 @@ def single_assignment_valid(s):
     except IndexError:
         return False
 
-def assign_reviewer(reviewer,paper_number):
+def get_nonreaders(paper_number):
+    # nonreaders are:
+    # (1) all authors of the paper
+    # (2) all domain groups of the authors of the paper
+
+    authors = client.get_group('auai.org/UAI/2017/Paper%s/Authors' % paper_number)
+    conflicts = set()
+    for author in authors.members:
+        try:
+            author_profile = client.get_profile(author)
+            conflicts.update([p.split('@')[1] for p in author_profile.content['emails']])
+        except openreview.OpenReviewException:
+            pass
+
+    if 'gmail.com' in conflicts: conflicts.remove('gmail.com')
+
+    return list(conflicts)
+
+def assign_reviewer(reviewer,paper_number,conflict_list):
     notes = [note for note in submissions if str(note.number)==str(paper_number)]
     valid_email = re.compile('^[^@\s,]+@[^@\s,]+\.[^@\s,]+$')
     valid_tilde = re.compile('~.+')
@@ -58,8 +76,7 @@ def assign_reviewer(reviewer,paper_number):
     elif not valid_email.match(reviewer) and not valid_tilde.match(reviewer):
         print "Program Committee Member \""+reviewer+"\" invalid. Please check for typos and whitespace."
     else:
-        #need to incorporate conflicts. get them from public profile? confirm this with UAI documentation
-        reviewer_group = get_reviewer_group(reviewer, paper_number, [])
+        reviewer_group = get_reviewer_group(reviewer, paper_number, conflict_list)
 
 
 def get_next_reviewer_id(reviewer, paper_number):
@@ -76,7 +93,7 @@ def get_next_reviewer_id(reviewer, paper_number):
         empty_reviewer_ids = []
         for existing_reviewer in reviewers:
             if reviewer in existing_reviewer.members:
-                print "reviewer " + reviewer + " found in " + existing_reviewer.id
+                print "Reviewer " + reviewer + " found in " + existing_reviewer.id
                 return None
 
             if len(existing_reviewer.members) == 0:
@@ -109,10 +126,15 @@ def get_reviewer_group(reviewer, paper_number, conflict_list):
 
     next_reviewer = get_next_reviewer_id(reviewer_profile.id, paper_number)
 
+    reviewers.nonreaders = conflict_list
+    client.post_group(reviewers)
+
     if next_reviewer:
         new_reviewer = create_reviewer_group(next_reviewer, reviewer_profile.id, paper_number, conflict_list)
         client.add_members_to_group(reviewers, [reviewer_profile.id])
-        client.add_members_to_group(nonreaders_reviewers, new_reviewer.id) # what is /Reviewers/NonReaders actually used for?
+        client.add_members_to_group(nonreaders_reviewers, new_reviewer.id)
+        print "Reviewer %s assigned to paper%s" % (reviewer, paper_number)
+
         return new_reviewer
 
 
@@ -137,22 +159,41 @@ def clear_assignments():
 
 # Main script
 # .............................................................................
-if args.overwrite and args.overwrite.lower() == 'true':
-    clear_assignments()
 
-if args.assignments:
-    if args.assignments.endswith('.csv'):
-        with open(args.assignments, 'rb') as csvfile:
-            reader = csv.reader(csvfile, delimiter=',', quotechar='|')
-            for row in reader:
-                reviewer = row[0]
-                paper_number = row[1]
-                assign_reviewer(reviewer,paper_number)
-                print "Reviewer %s assigned to paper%s" %(reviewer, paper_number)
-    elif single_assignment_valid(args.assignments):
-        reviewer = args.assignments.split(',')[0]
-        paper_number = args.assignments.split(',')[1]
-        assign_reviewer(reviewer,paper_number)
-    else:
-        print "Invalid input"
-        sys.exit()
+def assign(assignments):
+    for a in assignments:
+        reviewer = a[0]
+        paper_number = a[1]
+        conflict_list = get_nonreaders(paper_number)
+
+        members = set([g.id for g in client.get_groups(member=reviewer)])
+        assignee_conflicts = members.intersection(set(conflict_list))
+
+        user_continue = True
+        if len(assignee_conflicts) > 0:
+            print 'This assignment has the following conflicts: %s' % assignee_conflicts
+            user_continue = raw_input("Remove conflicts and continue? y/[n]: ").lower() == 'y'
+
+        if user_continue:
+            assign_reviewer(reviewer, paper_number, conflict_list)
+        else:
+            print "Paper %s not assigned" % paper_number
+
+
+if args.assignments.endswith('.csv'):
+    if args.overwrite and args.overwrite.lower() == 'true':
+        clear_assignments()
+
+    with open(args.assignments, 'rb') as csvfile:
+        assignments = csv.reader(csvfile, delimiter=',', quotechar='|')
+        assign(assignments)
+
+elif single_assignment_valid(args.assignments):
+    reviewer = args.assignments.split(',')[0]
+    paper_number = args.assignments.split(',')[1]
+    assignments = [(reviewer, paper_number)]
+    assign(assignments)
+
+else:
+    print "Invalid input"
+    sys.exit()

--- a/uai2017/python/assign-program-committee.py
+++ b/uai2017/python/assign-program-committee.py
@@ -175,6 +175,7 @@ def assign(assignments):
             user_continue = raw_input("Remove conflicts and continue? y/[n]: ").lower() == 'y'
 
         if user_continue:
+            [conflict_list.remove(conflict) for conflict in assignee_conflicts]
             assign_reviewer(reviewer, paper_number, conflict_list)
         else:
             print "Paper %s not assigned" % paper_number

--- a/uai2017/python/assign-program-committee.py
+++ b/uai2017/python/assign-program-committee.py
@@ -50,9 +50,7 @@ def single_assignment_valid(s):
         return False
 
 def get_nonreaders(paper_number):
-    # nonreaders are:
-    # (1) all authors of the paper
-    # (2) all domain groups of the authors of the paper
+    # nonreaders are a list of all domain groups of the authors of the paper
 
     authors = client.get_group('auai.org/UAI/2017/Paper%s/Authors' % paper_number)
     conflicts = set()

--- a/uai2017/python/assign-senior-program-committee.py
+++ b/uai2017/python/assign-senior-program-committee.py
@@ -115,6 +115,7 @@ def assign(assignments):
             user_continue = raw_input("Remove conflicts and continue? y/[n]: ").lower() == 'y'
 
         if user_continue:
+            [conflict_list.remove(conflict) for conflict in assignee_conflicts]
             assign_areachair(areachair, paper_number, conflict_list)
         else:
             print "Paper %s not assigned" % paper_number

--- a/uai2017/python/assign-senior-program-committee.py
+++ b/uai2017/python/assign-senior-program-committee.py
@@ -49,7 +49,25 @@ def single_assignment_valid(s):
     except IndexError:
         return False
 
-def assign_areachair(areachair, paper_number):
+def get_nonreaders(paper_number):
+    # nonreaders are:
+    # (1) all authors of the paper
+    # (2) all domain groups of the authors of the paper
+
+    authors = client.get_group('auai.org/UAI/2017/Paper%s/Authors' % paper_number)
+    conflicts = set()
+    for author in authors.members:
+        try:
+            author_profile = client.get_profile(author)
+            conflicts.update([p.split('@')[1] for p in author_profile.content['emails']])
+        except openreview.OpenReviewException:
+            pass
+
+    if 'gmail.com' in conflicts: conflicts.remove('gmail.com')
+
+    return list(conflicts)
+
+def assign_areachair(areachair, paper_number, conflict_list):
     notes = [note for note in submissions if str(note.number)==str(paper_number)]
     valid_email = re.compile('^[^@\s,]+@[^@\s,]+\.[^@\s,]+$')
     valid_tilde = re.compile('~.+')
@@ -58,9 +76,6 @@ def assign_areachair(areachair, paper_number):
     elif not valid_email.match(areachair) and not valid_tilde.match(areachair):
         print "Senior Program Committee Member \""+areachair+"\" invalid. Please check for typos and whitespace."
     else:
-        #need to incorporate conflicts
-        #areachair_group = get_areachair_group(areachair, paper_number, [])
-
         spc = client.get_group(SPC)
 
         areachair_profile = client.get_profile(areachair)
@@ -71,6 +86,7 @@ def assign_areachair(areachair, paper_number):
 
         acgroup = client.get_group('auai.org/UAI/2017/Paper%s/Area_Chair' % (paper_number) )
         acgroup.members = [areachair_profile.id]
+        acgroup.nonreaders = conflict_list
         client.post_group(acgroup);
         print "Area chair %s assigned to paper%s" %(areachair_profile.id,paper_number)
 
@@ -84,26 +100,44 @@ def clear_assignments():
 # Main script
 # .............................................................................
 
+def assign(assignments):
+    for a in assignments:
+        areachair = a[0]
+        paper_number = a[1]
+        conflict_list = get_nonreaders(paper_number)
+
+        members = set([g.id for g in client.get_groups(member=areachair)])
+        assignee_conflicts = members.intersection(set(conflict_list))
+
+        user_continue = True
+        if len(assignee_conflicts) > 0:
+            print 'This assignment has the following conflicts: %s' % assignee_conflicts
+            user_continue = raw_input("Remove conflicts and continue? y/[n]: ").lower() == 'y'
+
+        if user_continue:
+            assign_areachair(areachair, paper_number, conflict_list)
+        else:
+            print "Paper %s not assigned" % paper_number
 
 if args.assignments.endswith('.csv'):
-
     if args.overwrite and args.overwrite.lower() == 'true':
         clear_assignments()
 
     with open(args.assignments, 'rb') as csvfile:
-        reader = csv.reader(csvfile, delimiter=',', quotechar='|')
-        for row in reader:
-            areachair = row[0]
-            paper_number = row[1]
-            assign_areachair(areachair,paper_number)
+        assignments = csv.reader(csvfile, delimiter=',', quotechar='|')
+        assign(assignments)
 
 elif single_assignment_valid(args.assignments):
     areachair = args.assignments.split(',')[0]
     paper_number = args.assignments.split(',')[1]
 
+    # conflict_list = get_nonreaders(paper_number)
+    # assign_areachair(areachair, paper_number, conflict_list)
 
-    assign_areachair(areachair,paper_number)
-
+    assignments = [(areachair, paper_number)]
+    assign(assignments)
 else:
     print "Invalid input"
     sys.exit()
+
+

--- a/uai2017/python/assign-senior-program-committee.py
+++ b/uai2017/python/assign-senior-program-committee.py
@@ -50,9 +50,7 @@ def single_assignment_valid(s):
         return False
 
 def get_nonreaders(paper_number):
-    # nonreaders are:
-    # (1) all authors of the paper
-    # (2) all domain groups of the authors of the paper
+    # nonreaders are a list of all domain groups of the authors of the paper
 
     authors = client.get_group('auai.org/UAI/2017/Paper%s/Authors' % paper_number)
     conflicts = set()


### PR DESCRIPTION
for each of "assign-program-committee" and "assign-senior-program-committee", the script now finds all the conflict domains for the authors of the paper, and adds those domains as nonreaders to the groups Paper#/Reviewers, Paper#/Area_Chair and Paper#/AnonReviewer#

it also alerts you if you try to assign a reviewer or area chair to a paper with which they have a conflict, and gives you the option to either remove the conflict and continue, or to cancel the assignment (and move on, if you're assigning a list of users). This caused many problems for ICLR, because the user was not a reader of their own Reviewer or Area Chair group.