### PR TITLE
change due date, hide proceedings papers and fix description typo'

### DIFF
--- a/venues/roboticsfoundation.org/RSS/2017/RCW_Workshop/python/rssdata.py
+++ b/venues/roboticsfoundation.org/RSS/2017/RCW_Workshop/python/rssdata.py
@@ -13,5 +13,5 @@ PROCEEDINGS = CONFERENCE+"/-_Proceedings"
 POSTER_REVIEWERS = POSTER+"/Reviewers"
 PROCEEDINGS_REVIEWERS = PROCEEDINGS+"/Reviewers"
 # Due date May 21, 2017 at 5:00pm (here)
-DATE_DUE = datetime.datetime(2017, 5, 22, 7, 59)
+DATE_DUE = datetime.datetime(2017, 7, 16, 7, 59)
 TIMESTAMP_DUE = int(time.mktime(DATE_DUE.timetuple()))*1000

--- a/venues/roboticsfoundation.org/RSS/2017/RCW_Workshop/python/superuser-init.py
+++ b/venues/roboticsfoundation.org/RSS/2017/RCW_Workshop/python/superuser-init.py
@@ -149,8 +149,9 @@ if client.user['id'].lower()=='openreview.net':
         'forum': None,
         'replyto': None,
         'readers': {
+            ## Submissions to the Poster track are not visible to everyone, just to the people that need to know
             'description': 'The users who will be allowed to read the above content.',
-            'values': ['everyone']
+            'values-copied': [CONFERENCE, COCHAIRS, '{content.authorids}', '{signatures}']
         },
         'signatures': {
             'description': 'How your identity will be displayed with the above content.',
@@ -215,7 +216,7 @@ if client.user['id'].lower()=='openreview.net':
                 'required':True
             },
             'conflicts': {
-                'description': 'Comma separated list of email domains of people who would have a conflict of interest in reviewing this paper, (e.g., cs.umass.edu;google.com, etc.).',
+                'description': 'Comma separated list of email domains of people who would have a conflict of interest in reviewing this paper, (e.g., cs.umass.edu,google.com, etc.).',
                 'order': 9,
                 'values-regex': "[^;,\\n]+(,[^,\\n]+)*",
                 'required': True
@@ -262,15 +263,7 @@ if client.user['id'].lower()=='openreview.net':
                                               signatures=[POSTER],
                                               duedate=TIMESTAMP_DUE,
                                               process=utils.get_path('../process/submissionProcessPoster.js', __file__))
-
-    ## Submissions to the Poster track are not visible to everyone, just to the people that need to know
-    reply['readers'] = {
-            'description': 'The users who will be allowed to read the above content.',
-            'values-copied': [CONFERENCE, COCHAIRS, '{content.authorids}', '{signatures}']
-        }
-
     poster_invitation.reply = reply.copy()
-
     invitations.append(proceeding_invitation)
     invitations.append(poster_invitation)
 


### PR DESCRIPTION
Three requested changes:
1) [rssdata.py] extend due date indefinitely - so changed it to the end of the conference
2) [superuser-init.py] like the poster track, the proceeding papers are not visible to everyone - only chairs and authors
3) [superuser-init.py] in paper submission conflicts, change a ';' to a ',' since ;'s aren't accepted as a way to separate items.