### PR TITLE
For generic admin_init, use config.DUE_TIMESTAMP instead of hardcoded…

### DIFF
--- a/admin/conference-template/python/admin-init.template
+++ b/admin/conference-template/python/admin-init.template
@@ -35,7 +35,7 @@ groups[config.AREA_CHAIRS] = openreview.Group(config.AREA_CHAIRS, **config.group
 groups[config.REVIEWERS] = openreview.Group(config.REVIEWERS, **config.group_params)
 
 invitations = {}
-invitations[config.SUBMISSION] = openreview.Invitation(config.SUBMISSION, duedate=<<SUBMISSION_DUEDATE>>, **config.submission_params)
+invitations[config.SUBMISSION] = openreview.Invitation(config.SUBMISSION, duedate=config.DUE_TIMESTAMP, **config.submission_params)
 invitations[config.COMMENT] = openreview.Invitation(config.COMMENT, **config.comment_params)
 
 invitations[config.SUBMISSION].reply = templates.SubmissionReply().body


### PR DESCRIPTION
… number
This way when the duedate is changed, it only has to be changed in config.py and rerun admin_init.py instead of changing both files.