### PR TITLE
Feature/whi requests notebook

### DIFF
--- a/venues/ICML.cc/2017/WHI/python/create-revisions.py
+++ b/venues/ICML.cc/2017/WHI/python/create-revisions.py
@@ -1,0 +1,94 @@
+# import statements
+import openreview
+import config
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base url")
+parser.add_argument('--username')
+parser.add_argument('--password')
+args = parser.parse_args()
+
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+print client.baseurl
+
+# setup variables
+submissions = client.get_notes(invitation = config.SUBMISSION)
+
+# Adrian Weller, a PC and author, wasn't able to see how to modify PDF submissions.
+# This fix adds a revision invitation to all WHI papers.
+
+def revision_invitation(n):
+    revision_content = {
+        'title': {
+            'description': 'Title of paper.',
+            'order': 1,
+            'value-regex': '.{1,250}',
+            'required':True
+        },
+        'authors': {
+            'description': 'Comma separated list of author names.',
+            'order': 2,
+            'values-regex': "[^;,\\n]+(,[^,\\n]+)*",
+            'required':True
+        },
+        'authorids': {
+            'description': 'Comma separated list of author email addresses, lowercased, in the same order as above. For authors with existing OpenReview accounts, please make sure that the provided email address(es) match those listed in the author\'s profile.',
+            'order': 3,
+            'values-regex': "([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})",
+            'required':True
+        },
+        'keywords': {
+            'description': 'Comma separated list of keywords.',
+            'order': 6,
+            'values-regex': "(^$)|[^;,\\n]+(,[^,\\n]+)*"
+        },
+        'TL;DR': {
+            'description': '\"Too Long; Didn\'t Read\": a short sentence describing your paper',
+            'order': 7,
+            'value-regex': '[^\\n]{0,250}',
+            'required':False
+        },
+        'abstract': {
+            'description': 'Abstract of paper.',
+            'order': 8,
+            'value-regex': '[\\S\\s]{1,5000}',
+            'required':True
+        },
+        'pdf': {
+            'description': 'Upload a PDF file that ends with .pdf',
+            'order': 9,
+            'value-regex': 'upload',
+            'required':True
+        }
+    }
+
+    revision_reply = {
+        'content': revision_content,
+        'referent': n.id,
+        'forum': n.forum,
+        'readers': {
+            'description': 'The users who will be allowed to read the above content.',
+            'values': ['everyone']
+        },
+        'signatures': {
+            'description': 'How your identity will be displayed with the above content.',
+            'values-regex': '~.*'
+        },
+        'writers': {
+            'values-regex': '~.*'
+        }
+    }
+
+    return openreview.Invitation(config.CONF + '/-/Paper{0}/Add/Revision'.format(n.number),
+        readers = ['everyone'],
+        writers = [config.CONF],
+        invitees = n.content['authorids'],
+        signatures = [config.CONF],
+        reply = revision_reply
+        )
+
+
+for n in submissions:
+    inv = client.post_invitation(revision_invitation(n))
+    print inv.id

--- a/venues/ICML.cc/2017/WHI/python/requests.ipynb
+++ b/venues/ICML.cc/2017/WHI/python/requests.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "This notebook is used for responding to various pop-up requests from the program chairs of this conference.\n",
+    "\n",
+    "Write a comment indicating the request and any other information needed to reproduce the solution.\n",
+    "\n",
+    "Before committing this notebook, you should clear its output in the menu above: \n",
+    "\"Kernel\" --> \"Restart & Clear Output\"\n",
+    "\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# import statements\n",
+    "import openreview\n",
+    "import config\n",
+    "client = openreview.Client(baseurl='https://openreview.net')\n",
+    "print client.baseurl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# setup variables\n",
+    "submissions = client.get_notes(invitation = config.SUBMISSION)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Adrian Weller, a PC and author, wasn't able to see how to modify PDF submissions.\n",
+    "# This fix adds a revision invitation to all WHI papers.\n",
+    "\n",
+    "def revision_invitation(n):\n",
+    "    revision_content = {\n",
+    "        'title': {\n",
+    "            'description': 'Title of paper.',\n",
+    "            'order': 1,\n",
+    "            'value-regex': '.{1,250}',\n",
+    "            'required':True\n",
+    "        },\n",
+    "        'authors': {\n",
+    "            'description': 'Comma separated list of author names.',\n",
+    "            'order': 2,\n",
+    "            'values-regex': \"[^;,\\\\n]+(,[^,\\\\n]+)*\",\n",
+    "            'required':True\n",
+    "        },\n",
+    "        'authorids': {\n",
+    "            'description': 'Comma separated list of author email addresses, lowercased, in the same order as above. For authors with existing OpenReview accounts, please make sure that the provided email address(es) match those listed in the author\\'s profile.',\n",
+    "            'order': 3,\n",
+    "            'values-regex': \"([a-z0-9_\\-\\.]{2,}@[a-z0-9_\\-\\.]{2,}\\.[a-z]{2,},){0,}([a-z0-9_\\-\\.]{2,}@[a-z0-9_\\-\\.]{2,}\\.[a-z]{2,})\",\n",
+    "            'required':True\n",
+    "        },\n",
+    "        'keywords': {\n",
+    "            'description': 'Comma separated list of keywords.',\n",
+    "            'order': 6,\n",
+    "            'values-regex': \"(^$)|[^;,\\\\n]+(,[^,\\\\n]+)*\"\n",
+    "        },\n",
+    "        'TL;DR': {\n",
+    "            'description': '\\\"Too Long; Didn\\'t Read\\\": a short sentence describing your paper',\n",
+    "            'order': 7,\n",
+    "            'value-regex': '[^\\\\n]{0,250}',\n",
+    "            'required':False\n",
+    "        },\n",
+    "        'abstract': {\n",
+    "            'description': 'Abstract of paper.',\n",
+    "            'order': 8,\n",
+    "            'value-regex': '[\\\\S\\\\s]{1,5000}',\n",
+    "            'required':True\n",
+    "        },\n",
+    "        'pdf': {\n",
+    "            'description': 'Upload a PDF file that ends with .pdf',\n",
+    "            'order': 9,\n",
+    "            'value-regex': 'upload',\n",
+    "            'required':True\n",
+    "        }\n",
+    "    }\n",
+    "    \n",
+    "    revision_reply = {\n",
+    "        'content': revision_content,\n",
+    "        'referent': n.id,\n",
+    "        'forum': n.forum,\n",
+    "        'readers': {\n",
+    "            'description': 'The users who will be allowed to read the above content.',\n",
+    "            'values': ['everyone']\n",
+    "        },\n",
+    "        'signatures': {\n",
+    "            'description': 'How your identity will be displayed with the above content.',\n",
+    "            'values-regex': '~.*'\n",
+    "        },\n",
+    "        'writers': {\n",
+    "            'values-regex': '~.*'\n",
+    "        }\n",
+    "    }\n",
+    "    \n",
+    "    return openreview.Invitation(config.CONF + '/-/Paper{0}/Add/Revision'.format(n.number),\n",
+    "        readers = ['everyone'],\n",
+    "        writers = [config.CONF],\n",
+    "        invitees = n.content['authorids'],\n",
+    "        signatures = [config.CONF],\n",
+    "        reply = revision_reply\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Fix continued from above.\n",
+    "for n in submissions:\n",
+    "    inv = client.post_invitation(revision_invitation(n))\n",
+    "    print inv.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (openreview)",
+   "language": "python",
+   "name": "openreview"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/venues/ICML.cc/2017/WHI/python/requests.ipynb
+++ b/venues/ICML.cc/2017/WHI/python/requests.ipynb
@@ -56,6 +56,7 @@
    "source": [
     "# Adrian Weller, a PC and author, wasn't able to see how to modify PDF submissions.\n",
     "# This fix adds a revision invitation to all WHI papers.\n",
+    "# After running this solution, I added a script called create-revisions.py, which does the same thing.\n",
     "\n",
     "def revision_invitation(n):\n",
     "    revision_content = {\n",

--- a/venues/ICML.cc/2017/WHI/python/requests.ipynb
+++ b/venues/ICML.cc/2017/WHI/python/requests.ipynb
@@ -30,7 +30,7 @@
     "# import statements\n",
     "import openreview\n",
     "import config\n",
-    "client = openreview.Client(baseurl='https://openreview.net')\n",
+    "client = openreview.Client()\n",
     "print client.baseurl"
    ]
   },


### PR DESCRIPTION
We don't normally commit .ipynb files, but I'm committing this one because I think we need a better way of keeping track of program chair requests and sharing the solutions between ourselves.

I propose to add a "requests.ipynb" file to each venue's /python directory. It will contain the solutions to pop-up requests made by program chairs, and any notes or comments related to those requests.

This one is for WHI, and includes a solution to add revisions to papers. I also created a .py script that does the same thing.