### PR TITLE
fix assignment and metadata note invitation IDs

### DIFF
--- a/venues/auai.org/UAI/2017/python/superuser-init.py
+++ b/venues/auai.org/UAI/2017/python/superuser-init.py
@@ -13,6 +13,7 @@ from config import *
 import sys, os
 import subprocess
 import argparse
+import config
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--baseurl', help="base URL")
@@ -479,7 +480,7 @@ if client.user['id'].lower()=='openreview.net':
         'content': {}
     }
 
-    paper_metadata_invitation = openreview.Invitation(CONFERENCE+'/-/Paper_Metadata',
+    paper_metadata_invitation = openreview.Invitation(config.METADATA,
                                                writers=['OpenReview.net'],
                                                readers=[CONFERENCE],
                                                invitees=[CONFERENCE],
@@ -507,7 +508,7 @@ if client.user['id'].lower()=='openreview.net':
     }
 
     #Create the matching assignments invitation
-    matching_assignments_invitation = openreview.Invitation(CONFERENCE + '/-/Matching_Assignments',
+    matching_assignments_invitation = openreview.Invitation(config.ASSIGNMENT,
                                                 writers = ['OpenReview.net'],
                                                 readers = [CONFERENCE],
                                                 invitees = [CONFERENCE],


### PR DESCRIPTION
@zbialecki just found another minor bug, caused by my renaming of the various matching invitations.

You should be able to re-run superuser-init after you've already run basic-metadata, so you don't have to go through the time-consuming process of running it again