### PR TITLE
fixed matching arguments

### DIFF
--- a/admin/match.py
+++ b/admin/match.py
@@ -10,7 +10,7 @@ import openreview_matcher
 
 # Argument handling
 parser = argparse.ArgumentParser()
-parser.add_argument('-c','--config', help='the ID of the configuration note to use', required=True)
+parser.add_argument('config', help='the ID of the configuration note to use')
 parser.add_argument('--username')
 parser.add_argument('--password')
 parser.add_argument('--baseurl', help="base URL")


### PR DESCRIPTION
makes the argument required, without using a flag.

usage used to be this:

python match.py --config <paperID>

now it's this:

python match.py <paperID>