### PR TITLE
new withdraw procedure

### DIFF
--- a/venues/ICLR.cc/2018/Conference/process/submissionProcess.js
+++ b/venues/ICLR.cc/2018/Conference/process/submissionProcess.js
@@ -12,6 +12,27 @@ function() {
     var AREA_CHAIRS_PLUS = AREA_CHAIRS + '_and_Higher';
     var BLIND_SUBMISSION = CONF + '/-/Blind_Submission';
 
+    var withdrawProcess = `function() {
+      var or3client = lib.or3client;
+
+      var CONF = 'ICLR.cc/2018/Conference';
+      var BLIND_INVITATION = CONF + '/-/Blind_Submission';
+
+      or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
+      .then(result => {
+        var blindedNote = result.notes[0];
+
+        var milliseconds = (new Date).getTime();
+        blindedNote.ddate = milliseconds
+        console.log('blindedNotes ' + JSON.stringify(blindedNote))
+        return blindedNote;
+      })
+      .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
+      .then(result => done())
+      .catch(error => done(error));
+      return true;
+    }`
+
     var getBibtex = function(note) {
       var firstWord = note.content.title.split(' ')[0].toLowerCase();
 
@@ -100,6 +121,7 @@ function() {
           invitees: [authorGroupId],
           noninvitees: [],
           readers: ['everyone'],
+          process: withdrawProcess,
           reply: {
             forum: savedNote.id,
             referent: savedNote.id,
@@ -108,7 +130,7 @@ function() {
             readers: invitation.reply.readers,
             content: {
               withdrawal: {
-                description: 'Confirm your withdrawal',
+                description: 'Confirm your withdrawal. The blind record of your paper will be deleted. Your identity will NOT be revealed. This cannot be undone.',
                 order: 1,
                 'value-radio': ['Confirmed'],
                 required: true

--- a/venues/ICLR.cc/2018/Conference/process/submissionProcess.js
+++ b/venues/ICLR.cc/2018/Conference/process/submissionProcess.js
@@ -27,7 +27,7 @@ function() {
                 blindedNote.ddate = milliseconds
                 return blindedNote;
             } else {
-                console.log('No notes with the referent ' + note.referent + ' were found');
+                return Promise.reject('No notes with the referent ' + note.referent + ' were found');
             }
         })
         .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))

--- a/venues/ICLR.cc/2018/Conference/process/submissionProcess.js
+++ b/venues/ICLR.cc/2018/Conference/process/submissionProcess.js
@@ -13,24 +13,27 @@ function() {
     var BLIND_SUBMISSION = CONF + '/-/Blind_Submission';
 
     var withdrawProcess = `function() {
-      var or3client = lib.or3client;
+        var or3client = lib.or3client;
 
-      var CONF = 'ICLR.cc/2018/Conference';
-      var BLIND_INVITATION = CONF + '/-/Blind_Submission';
+        var CONF = 'ICLR.cc/2018/Conference';
+        var BLIND_INVITATION = CONF + '/-/Blind_Submission';
 
-      or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
-      .then(result => {
-        var blindedNote = result.notes[0];
+        or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
+        .then(result => {
+            if (result.notes.length > 0){
+                var blindedNote = result.notes[0];
 
-        var milliseconds = (new Date).getTime();
-        blindedNote.ddate = milliseconds
-        console.log('blindedNotes ' + JSON.stringify(blindedNote))
-        return blindedNote;
-      })
-      .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
-      .then(result => done())
-      .catch(error => done(error));
-      return true;
+                var milliseconds = (new Date).getTime();
+                blindedNote.ddate = milliseconds
+                return blindedNote;
+            } else {
+                console.log('No notes with the referent ' + note.referent + ' were found');
+            }
+        })
+        .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
+        .then(result => done())
+        .catch(error => done(error));
+        return true;
     }`
 
     var getBibtex = function(note) {

--- a/venues/ICLR.cc/2018/Conference/process/submissionProcess_fast.js
+++ b/venues/ICLR.cc/2018/Conference/process/submissionProcess_fast.js
@@ -8,6 +8,29 @@ function() {
     var AUTHORS = CONF + '/Authors';
     var BLIND_SUBMISSION = CONF + '/-/Blind_Submission';
 
+
+    var withdrawProcess = `function() {
+      var or3client = lib.or3client;
+
+      var CONF = 'ICLR.cc/2018/Conference';
+      var BLIND_INVITATION = CONF + '/-/Blind_Submission';
+
+      or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
+      .then(result => {
+        var blindedNote = result.notes[0];
+
+        var milliseconds = (new Date).getTime();
+        blindedNote.ddate = milliseconds
+        console.log('blindedNotes ' + JSON.stringify(blindedNote))
+        return blindedNote;
+      })
+      .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
+      .then(result => done())
+      .catch(error => done(error));
+      return true;
+    }`
+
+
     var getBibtex = function(note) {
       var firstWord = note.content.title.split(' ')[0].toLowerCase();
 
@@ -91,6 +114,7 @@ function() {
           invitees: [authorGroupId],
           noninvitees: [],
           readers: ['everyone'],
+          process: withdrawProcess,
           reply: {
             forum: savedNote.id,
             referent: savedNote.id,
@@ -99,7 +123,7 @@ function() {
             readers: invitation.reply.readers,
             content: {
               withdrawal: {
-                description: 'Confirm your withdrawal',
+                description: 'Confirm your withdrawal. The blind record of your paper will be deleted. Your identity will NOT be revealed. This cannot be undone.',
                 order: 1,
                 'value-radio': ['Confirmed'],
                 required: true

--- a/venues/ICLR.cc/2018/Conference/process/submissionProcess_fast.js
+++ b/venues/ICLR.cc/2018/Conference/process/submissionProcess_fast.js
@@ -10,24 +10,27 @@ function() {
 
 
     var withdrawProcess = `function() {
-      var or3client = lib.or3client;
+        var or3client = lib.or3client;
 
-      var CONF = 'ICLR.cc/2018/Conference';
-      var BLIND_INVITATION = CONF + '/-/Blind_Submission';
+        var CONF = 'ICLR.cc/2018/Conference';
+        var BLIND_INVITATION = CONF + '/-/Blind_Submission';
 
-      or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
-      .then(result => {
-        var blindedNote = result.notes[0];
+        or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
+        .then(result => {
+            if (result.notes.length > 0){
+                var blindedNote = result.notes[0];
 
-        var milliseconds = (new Date).getTime();
-        blindedNote.ddate = milliseconds
-        console.log('blindedNotes ' + JSON.stringify(blindedNote))
-        return blindedNote;
-      })
-      .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
-      .then(result => done())
-      .catch(error => done(error));
-      return true;
+                var milliseconds = (new Date).getTime();
+                blindedNote.ddate = milliseconds
+                return blindedNote;
+            } else {
+                return Promise.reject('No notes with the referent ' + note.referent + ' were found');
+            }
+        })
+        .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
+        .then(result => done())
+        .catch(error => done(error));
+        return true;
     }`
 
 

--- a/venues/ICLR.cc/2018/Conference/process/withdrawProcess_delete.js
+++ b/venues/ICLR.cc/2018/Conference/process/withdrawProcess_delete.js
@@ -13,7 +13,7 @@ function() {
             blindedNote.ddate = milliseconds
             return blindedNote;
         } else {
-            console.log('No notes with the referent ' + note.referent + ' were found');
+            return Promise.reject('No notes with the referent ' + note.referent + ' were found');
         }
     })
     .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))

--- a/venues/ICLR.cc/2018/Conference/process/withdrawProcess_delete.js
+++ b/venues/ICLR.cc/2018/Conference/process/withdrawProcess_delete.js
@@ -1,0 +1,20 @@
+function() {
+    var or3client = lib.or3client;
+
+    var CONF = 'ICLR.cc/2018/Conference';
+    var BLIND_INVITATION = CONF + '/-/Blind_Submission';
+
+    or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
+    .then(result => {
+        var blindedNote = result.notes[0];
+
+        var milliseconds = (new Date).getTime();
+        blindedNote.ddate = milliseconds
+        console.log('blindedNotes ' + JSON.stringify(blindedNote))
+        return blindedNote;
+    })
+    .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
+    .then(result => done())
+    .catch(error => done(error));
+    return true;
+}

--- a/venues/ICLR.cc/2018/Conference/process/withdrawProcess_delete.js
+++ b/venues/ICLR.cc/2018/Conference/process/withdrawProcess_delete.js
@@ -6,12 +6,15 @@ function() {
 
     or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
     .then(result => {
-        var blindedNote = result.notes[0];
+        if (result.notes.length > 0){
+            var blindedNote = result.notes[0];
 
-        var milliseconds = (new Date).getTime();
-        blindedNote.ddate = milliseconds
-        console.log('blindedNotes ' + JSON.stringify(blindedNote))
-        return blindedNote;
+            var milliseconds = (new Date).getTime();
+            blindedNote.ddate = milliseconds
+            return blindedNote;
+        } else {
+            console.log('No notes with the referent ' + note.referent + ' were found');
+        }
     })
     .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
     .then(result => done())

--- a/venues/ICLR.cc/2018/Conference/process/withdrawProcess_reveal.js
+++ b/venues/ICLR.cc/2018/Conference/process/withdrawProcess_reveal.js
@@ -14,7 +14,7 @@ function() {
             blindedNote.ddate = milliseconds
             return blindedNote;
         } else {
-            console.log('No notes with the referent ' + note.referent + ' were found');
+            return Promise.reject('No notes with the referent ' + note.referent + ' were found');
         }
     })
     .catch(error => done(error))

--- a/venues/ICLR.cc/2018/Conference/process/withdrawProcess_reveal.js
+++ b/venues/ICLR.cc/2018/Conference/process/withdrawProcess_reveal.js
@@ -7,15 +7,20 @@ function() {
 
     or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
     .then(result => {
-        var blindedNote = result.notes[0];
+        if(result.notes.length > 0){
+            var blindedNote = result.notes[0];
 
-        var milliseconds = (new Date).getTime();
-        blindedNote.ddate = milliseconds
-        return blindedNote;
+            var milliseconds = (new Date).getTime();
+            blindedNote.ddate = milliseconds
+            return blindedNote;
+        } else {
+            console.log('No notes with the referent ' + note.referent + ' were found');
+        }
     })
+    .catch(error => done(error))
     .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
     .then(result => {
-        console.log('result: ' + JSON.stringify(result));
+        console.log('Withdrawing note: ' + JSON.stringify(result));
         var withdrawn_submission = {
             original: result.original,
             invitation: WITHDRAWN_INVITATION,

--- a/venues/ICLR.cc/2018/Conference/process/withdrawProcess_reveal.js
+++ b/venues/ICLR.cc/2018/Conference/process/withdrawProcess_reveal.js
@@ -1,0 +1,34 @@
+function() {
+    var or3client = lib.or3client;
+
+    var CONF = 'ICLR.cc/2018/Conference';
+    var BLIND_INVITATION = CONF + '/-/Blind_Submission';
+    var WITHDRAWN_INVITATION = CONF + '/-/Withdrawn_Submission';
+
+    or3client.or3request(or3client.notesUrl + '?id=' + note.referent, {}, 'GET', token)
+    .then(result => {
+        var blindedNote = result.notes[0];
+
+        var milliseconds = (new Date).getTime();
+        blindedNote.ddate = milliseconds
+        return blindedNote;
+    })
+    .then(blindedNote => or3client.or3request(or3client.notesUrl, blindedNote, 'POST', token))
+    .then(result => {
+        console.log('result: ' + JSON.stringify(result));
+        var withdrawn_submission = {
+            original: result.original,
+            invitation: WITHDRAWN_INVITATION,
+            forum: null,
+            parent: null,
+            signatures: [CONF],
+            writers: [CONF],
+            readers: ['everyone'],
+            content: {}
+        }
+        return or3client.or3request(or3client.notesUrl, withdrawn_submission, 'POST', token);
+    })
+    .then(result => done())
+    .catch(error => done(error));
+    return true;
+}

--- a/venues/ICLR.cc/2018/Conference/python/admin-init.py
+++ b/venues/ICLR.cc/2018/Conference/python/admin-init.py
@@ -53,6 +53,9 @@ invitations[config.SUBMISSION] = openreview.Invitation(
 invitations[config.BLIND_SUBMISSION] = openreview.Invitation(
 	config.BLIND_SUBMISSION, **config.blind_submission_params)
 
+invitations[config.WITHDRAWN_SUBMISSION] = openreview.Invitation(
+	config.WITHDRAWN_SUBMISSION, **config.withdrawn_submission_params)
+
 invitations[config.PUBLIC_COMMENT] = openreview.Invitation(
 	config.PUBLIC_COMMENT, **config.public_comment_params)
 

--- a/venues/ICLR.cc/2018/Conference/python/config.py
+++ b/venues/ICLR.cc/2018/Conference/python/config.py
@@ -228,6 +228,39 @@ blind_submission_params = {
     }
 }
 
+"""
+/-/Withdrawn_Submission
+
+This is an invitation that gets fulfilled when a user withdraws a submission
+after the submission deadline. Setting withdrawals up this way allows us to
+easily put all withdrawn notes in a single tab.
+
+"""
+WITHDRAWN_SUBMISSION = CONF + '/-/Withdrawn_Submission'
+
+withdrawn_submission_params = {
+    'readers': ['everyone'],
+    'writers': [CONF],
+    'invitees': [CONF],
+    'signatures': [CONF],
+    'reply': {
+        'forum': None,
+        'replyto': None,
+        'readers': {
+            'description': 'The users who will be allowed to read the above content.',
+            'values': ['everyone']
+        },
+        'signatures': {
+            'description': 'How your identity will be displayed with the above content.',
+            'values': [CONF]
+        },
+        'writers': {
+            'values': [CONF]
+        },
+        'content': {}
+    }
+}
+
 
 """
 /-/Public_Comment
@@ -469,6 +502,7 @@ withdraw_paper_params = {
     'writers': [CONF],
     'invitees': [],
     'signatures': [CONF],
+    'process': os.path.abspath(os.path.join(os.path.dirname(__file__), '../process/withdrawProcess_reveal.js')),
     'reply': {
         'referent': None, # replaced in invitations.py
         'forum': None, # replaced in invitations.py
@@ -485,7 +519,10 @@ withdraw_paper_params = {
         },
         'content':{
             'withdrawal': {
-                'description': 'Confirm your withdrawal',
+                # For withdrawProcess_delete.js:
+                #'description': 'Confirm your withdrawal. The blind record of your paper will be deleted. Your identity will NOT be revealed. This cannot be undone.',
+                # For withdrawProcess_reveal.js:
+                'description': 'Confirm your withdrawal. Your identity will be revealed to the public. This cannot be undone.',
                 'order': 1,
                 'value-radio': ['Confirmed'],
                 'required':True

--- a/venues/ICLR.cc/2018/Conference/python/convert-withdrawal-procedure.py
+++ b/venues/ICLR.cc/2018/Conference/python/convert-withdrawal-procedure.py
@@ -1,0 +1,47 @@
+'''
+
+This is a one-time script that should be run to convert the conference to the new withdrawal protocol.
+
+'''
+
+import openreview
+import config
+import csv
+client = openreview.Client()
+print client.baseurl
+
+# set up the new withdrawal procedure
+
+# re-post the submission invitation (slow)
+client.post_invitation(openreview.Invitation(config.SUBMISSION, duedate=config.DUE_TIMESTAMP, **config.submission_params))
+
+# post the withdrawn submissions invitation
+client.post_invitation(openreview.Invitation(config.WITHDRAWN_SUBMISSION, **config.withdrawn_submission_params))
+
+# find all the improperly withdrawn notes
+blinded = client.get_notes(invitation=config.BLIND_SUBMISSION)
+withdrawn_blinded = [n for n in blinded if 'withdrawal' in n.content]
+for w in withdrawn_blinded:
+    print w.id, w.content['title']
+
+# for all blinded notes, update the withdraw paper invitation
+for n in blinded:
+    withdraw_inv = client.get_invitation('ICLR.cc/2018/Conference/-/Paper{0}/Withdraw_Paper'.format(n.number))
+    with open('../process/withdrawProcess_delete.js') as f:
+        withdraw_inv.process = f.read()
+    withdraw_inv.reply['content']['withdrawal']['description'] = 'Confirm your withdrawal. The blind record of your paper will be deleted. Your identity will NOT be revealed. This cannot be undone.'
+    client.post_invitation(withdraw_inv)
+
+# for each of these notes, set the ddate to be the date that the withdrawal was made:
+for n in withdrawn_blinded:
+    rev = client.get_revisions(n.id)
+    withdrawals = [r for r in rev if 'Withdraw_Paper' in r.invitation]
+    ddate = sorted([w.cdate for w in withdrawals])[0]
+    print ddate
+    n.ddate = ddate
+    client.post_note(n)
+
+# update webfield
+conference = client.get_group(config.CONF)
+conference.add_webfield('../webfield/conferenceWebfield_alt.js')
+client.post_group(conference)

--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_alt.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_alt.js
@@ -203,7 +203,7 @@ function renderContent(notes, submittedNotes, assignedNotePairs, userGroups, tag
     }
     if (note.invitation === INVITATION) {
       submittedPapers.push(note);
-    } else if (note.invitation !== RECRUIT_REVIEWERS) {
+    } else if (note.invitation !== RECRUIT_REVIEWERS && note.invitation !== WITHDRAWN_INVITATION) {
       // ICLR specific: Not all conferences will have this invitation
       commentNotes.push(note);
     }
@@ -314,36 +314,12 @@ function renderContent(notes, submittedNotes, assignedNotePairs, userGroups, tag
   });
 
   if (withdrawnNotes.length) {
-    Webfield.ui.submissionList(withdrawnNotes, {
-      heading: null,
-      container: '#withdrawn-papers',
-      search: {
-        enabled: true,
-        subjectAreas: SUBJECT_AREAS_LIST,
-        onResults: function(searchResults) {
-          var withdrawnSearchResults = searchResults.filter(function(note) {
-            return note.invitation === WITHDRAWN_INVITATION;
-          });
-          Webfield.ui.searchResults(withdrawnSearchResults, withdrawnListOptions);
-          Webfield.disableAutoLoading();
-        },
-        onReset: function() {
-          Webfield.ui.searchResults(withdrawnNotes, withdrawnListOptions);
-          if (withdrawnNotes.length === PAGE_SIZE) {
-            Webfield.setupAutoLoading(WITHDRAWN_INVITATION, PAGE_SIZE, withdrawnListOptions);
-          }
-        }
-      },
-      displayOptions: withdrawnListOptions,
-      fadeIn: false
-    });
+    Webfield.ui.searchResults(
+      withdrawnNotes,
+      _.assign({}, paperDisplayOptions, {container: '#withdrawn-papers'})
+    );
   } else {
     $('.tabs-container a[href="#withdrawn-papers"]').parent().hide();
-  }
-
-
-  if (withdrawnNotes.length === PAGE_SIZE) {
-    Webfield.setupAutoLoading(WITHDRAWN_INVITATION, PAGE_SIZE, withdrawnListOptions);
   }
 
   // My Submitted Papers tab

--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_alt.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_alt.js
@@ -311,7 +311,7 @@ function renderContent(notes, submittedNotes, assignedNotePairs, userGroups, tag
     fadeIn: false
   });
 
-  if (allNotes.length === PAGE_SIZE) {
+  if (notes.length === PAGE_SIZE) {
     Webfield.setupAutoLoading(BLIND_INVITATION, PAGE_SIZE, submissionListOptions);
   }
 

--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_alt.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_alt.js
@@ -324,7 +324,7 @@ function renderContent(notes, submittedNotes, assignedNotePairs, userGroups, tag
   if (withdrawnNotes.length) {
     Webfield.ui.searchResults(
       withdrawnNotes,
-      _.assign({}, paperDisplayOptions, {container: '#withdrawn-papers'})
+      withdrawnListOptions,
     );
   } else {
     $('.tabs-container a[href="#withdrawn-papers"]').parent().hide();


### PR DESCRIPTION
Instead of filtering by the "withdrawal" property every time you do a "get" for Blind Submission notes, with these changes a withdrawal will delete the blind note.

If an author withdraws after the submission deadline, in addition to the above, a new note gets created that responds to the invitation "ICLR.cc/2018/Conference/-/Withdrawn_Submission". These can then get separately organized in a new tab (with the authors' identities revealed).

the script "convert-withdrawal-procedure.py" will convert the existing notes and process functions to the new protocol. To test this, you should restore your local database to match the live site, then run convert-withdrawal-procedure.py. From there you can post notes (or impersonate other users) and withdraw them to see how it works.

After the submission deadline, I'll run:

`python invitations.py Withdraw_Paper --enable --overwrite`

This will update all the Withdraw_Paper invitations with the "withdrawPaper_reveal.js" process function. Once you do that, withdrawing papers will sort them into the "Withdrawn Papers" tab.

Let me know if you have questions!