### PR TITLE
change default tab order

### DIFF
--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
@@ -146,6 +146,10 @@ function renderSubmissionButton() {
 function renderConferenceTabs() {
   var sections = [
     {
+      heading: 'All Submitted Papers',
+      id: 'all-submitted-papers',
+    },
+    {
       heading: 'My Tasks',
       id: 'my-tasks',
     },
@@ -160,10 +164,6 @@ function renderConferenceTabs() {
     {
       heading: 'My Comments & Reviews',
       id: 'my-comments-reviews',
-    },
-    {
-      heading: 'All Submitted Papers',
-      id: 'all-submitted-papers',
     },
     {
       heading: 'Withdrawn Papers',


### PR DESCRIPTION
the ICLR PCs requested that the All Submitted Papers tab come first

I'm going to deploy this change on the live site, since it's easy to revert