### PR TITLE
Feature/rebuttal period

### DIFF
--- a/venues/ICLR.cc/2018/Conference/process/officialReviewProcess_withRevision.js
+++ b/venues/ICLR.cc/2018/Conference/process/officialReviewProcess_withRevision.js
@@ -1,0 +1,61 @@
+//EDIT ME
+
+function(){
+    var or3client = lib.or3client;
+
+    var origNote = or3client.or3request(or3client.notesUrl+'?id='+note.forum, {}, 'GET', token);
+    var list = note.invitation.replace(/_/g,' ').split('/');
+    list.splice(list.indexOf('-',1));
+    var conference = list.join(' ');
+
+    origNote.then(function(result) {
+      var forum = result.notes[0];
+      var note_number = forum.number;
+
+      var reviewers = ['ICLR.cc/2018/Conference/Paper' + note_number + '/Reviewers'];
+      var areachairs = ['ICLR.cc/2018/Conference/Paper' + note_number + '/Area_Chair'];
+      var authors = forum.content.authorids;
+
+      var areachair_mail = {
+        "groups": areachairs,
+        "subject": "Review posted to your assigned paper: \"" + forum.content.title + "\"",
+        "message": "A submission to " + conference + ", for which you are an official area chair, has received an official review. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.review + "\n\nTo view the review, click here: " + baseUrl + "/forum?id=" + note.forum
+      };
+      var areachairMailP = or3client.or3request( or3client.mailUrl, areachair_mail, 'POST', token );
+
+      return areachairMailP;
+    })
+    .then(result => or3client.addInvitationNoninvitee(note.invitation, note.signatures[0], token))
+    .then(result => or3client.or3request(or3client.inviteUrl+'?id='+note.invitation, {}, 'GET', token))
+    .then(result => {
+      var reviewInvitation = result.invitations[0];
+      var signatureComponents = note.signatures[0].split('/');
+      console.log('signature components: ' + signatureComponents);
+      var anonReviewerPaper = signatureComponents
+      var revisionInvitation = {
+        'id': 'ICLR.cc/2018/Conference/-/'+signatureComponents[4]+'/'+signatureComponents[3]+'/Revise_Review',
+        'writers': ['ICLR.cc/2018/Conference'],
+        'signatures': ['ICLR.cc/2018/Conference'],
+        'readers': ['everyone'],
+        'invitees': note.signatures,
+        'reply': {
+            'forum': note.forum,
+            'referent': note.id,
+            'writers': {
+                'values': ['ICLR.cc/2018/Conference']
+            },
+            'signatures': {
+                'values-regex': note.signatures[0] + '|ICLR.cc/2018/Conference'
+            },
+            'readers': {
+                'values':['everyone']
+            },
+            'content': reviewInvitation.reply.content
+        }
+      };
+      return or3client.or3request(or3client.inviteUrl, revisionInvitation, 'POST', token);
+    })
+    .then(result => done())
+    .catch(error => done(error));
+    return true;
+  };

--- a/venues/ICLR.cc/2018/Conference/python/review-revisions.py
+++ b/venues/ICLR.cc/2018/Conference/python/review-revisions.py
@@ -1,0 +1,60 @@
+import openreview
+import argparse
+import config
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--username')
+parser.add_argument('--password')
+parser.add_argument('--baseurl', help = "base URL")
+args = parser.parse_args()
+
+client = openreview.Client(username=args.username, password=args.password, baseurl=args.baseurl)
+
+def create_revision_invitation(forum, referent, signature):
+    params = {
+        'writers': [config.CONF],
+        'signatures': [config.CONF],
+        'readers': ['everyone'],
+        'invitees': [signature],
+        'reply': {
+            'forum': forum,
+            'referent': referent,
+            'writers': {
+                'values': [config.CONF]
+            },
+            'signatures': {
+                'values-regex': signature + '|ICLR.cc/2018/Conference'
+            },
+            'readers': {
+                'values':['everyone']
+            },
+            'content': config.official_review_params['reply']['content']
+        }
+    }
+
+    signature_components = signature.split('/')
+    paper_num = signature_components[3]
+    anonreviewer = signature_components[4]
+
+    revise_review = openreview.Invitation('ICLR.cc/2018/Conference/-/{0}/{1}/Revise_Review'.format(anonreviewer, paper_num), **params)
+    return revise_review
+
+review_invitations = client.get_invitations(regex = config.CONF + '/-/Paper.*/Official_Review')
+reviews = client.get_notes(invitation = config.CONF + '/-/Paper.*/Official_Review')
+
+for inv in review_invitations:
+    forum_reviews = [r for r in reviews if r.forum == inv.reply['forum']]
+
+    inv.reply['writers'] = {'values': []}
+    with open('../process/officialReviewProcess_withRevision.js') as f:
+        inv.process = f.read()
+    inv = client.post_invitation(inv)
+
+    for review in forum_reviews:
+        print "updating review: ", review.id
+        review.readers = ['everyone']
+        review.writers = []
+        client.post_note(review)
+        review_revision_invitation = create_revision_invitation(review.forum, review.id, review.signatures[0])
+        print "posting review revision invitation ", review_revision_invitation.id
+        client.post_invitation(review_revision_invitation)

--- a/venues/ICLR.cc/2018/Conference/python/visibility.py
+++ b/venues/ICLR.cc/2018/Conference/python/visibility.py
@@ -66,18 +66,15 @@ if args.type == 'reviews' or args.type == 'metareviews':
         forum_reviews = [r for r in reviews if r.forum == inv.reply['forum']]
 
         if args.show and not args.hide:
-            if forum_reviews:
-                inv.reply['readers']['values'] = ['everyone']
-                inv.invitees = []
-                inv.reply['writers']['values'] = []
-                inv = client.post_invitation(inv)
-                print "updating invitation ", inv.id
+
+            inv.reply['readers']['values'] = ['everyone']
+            inv = client.post_invitation(inv)
+            print "updating invitation ", inv.id
 
             for review in forum_reviews:
                 print "updating review: ",review.id
                 review.readers = ['everyone']
                 review.nonreaders = []
-                review.writers = []
                 client.post_note(review)
 
         if args.hide and not args.show:

--- a/venues/ICLR.cc/2018/Conference/python/visibility.py
+++ b/venues/ICLR.cc/2018/Conference/python/visibility.py
@@ -66,14 +66,18 @@ if args.type == 'reviews' or args.type == 'metareviews':
         forum_reviews = [r for r in reviews if r.forum == inv.reply['forum']]
 
         if args.show and not args.hide:
-            inv.reply['readers']['values'] = ['everyone']
-            inv.invitees = []
-            inv = client.post_invitation(inv)
-            print "updating invitation ", inv.id
+            if forum_reviews:
+                inv.reply['readers']['values'] = ['everyone']
+                inv.invitees = []
+                inv.reply['writers']['values'] = []
+                inv = client.post_invitation(inv)
+                print "updating invitation ", inv.id
 
             for review in forum_reviews:
                 print "updating review: ",review.id
                 review.readers = ['everyone']
+                review.nonreaders = []
+                review.writers = []
                 client.post_note(review)
 
         if args.hide and not args.show:


### PR DESCRIPTION
these are new and updated scripts to transition ICLR from the reviewing period to the rebuttal period.

to make the transition, I will do the following:

1) reveal the existing reviews to the public and change the invitation so that future reviews will be public too:
`python visibility.py --show reviews`

2) enable revisions on all existing papers
`python invitations.py --enable Add_Revision`

3) add revision invitations to official reviews, so that we can keep track of review revisions during the rebuttal period. Also update the process function so that revisions are created when late reviews are made.
`python review-revisions.py`