### PR TITLE
Fix/author notes in tabs

### DIFF
--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
@@ -235,17 +235,12 @@ function renderContent(notes, submittedNotes, assignedNotePairs, userGroups, aut
   if (assignedPaperNumbers.length !== assignedNotes.length) {
     console.warn('WARNING: The number of assigned notes returned by API does not ' +
       'match the number of assigned note groups the user is a member of.');
-
-    console.log(assignedPaperNumbers);
-    console.log(assignedNotes);
   }
 
   var authorPaperNumbers = getAuthorPaperNumbersfromGroups(userGroups);
   if (authorPaperNumbers.length !== authorNotes.length) {
     console.warn('WARNING: The number of submitted notes returned by API does not ' +
       'match the number of submitted note groups the user is a member of.');
-    console.log(authorPaperNumbers);
-    console.log(authorNotes);
   }
 
   // My Tasks tab

--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
@@ -89,11 +89,15 @@ function load() {
       );
     });
 
-    authorNotesP = Webfield.get('/notes/search', {
-      term: user.id,
-      group: CONFERENCE,
-      content: 'authors',
-      source: 'forum'
+    authorNotesP = Webfield.get('/user/profile', {
+      email: user.id
+    }).then(function(result){
+      return Webfield.get('/notes/search', {
+        term: result.profile.id,
+        group: 'all',
+        content: 'authors',
+        source: 'forum'
+      })
     }).then(function(result) {
       return result.notes;
     });
@@ -231,12 +235,17 @@ function renderContent(notes, submittedNotes, assignedNotePairs, userGroups, aut
   if (assignedPaperNumbers.length !== assignedNotes.length) {
     console.warn('WARNING: The number of assigned notes returned by API does not ' +
       'match the number of assigned note groups the user is a member of.');
+
+    console.log(assignedPaperNumbers);
+    console.log(assignedNotes);
   }
 
   var authorPaperNumbers = getAuthorPaperNumbersfromGroups(userGroups);
   if (authorPaperNumbers.length !== authorNotes.length) {
     console.warn('WARNING: The number of submitted notes returned by API does not ' +
       'match the number of submitted note groups the user is a member of.');
+    console.log(authorPaperNumbers);
+    console.log(authorNotes);
   }
 
   // My Tasks tab


### PR DESCRIPTION
fixes a bug caused by passing the email address instead of user ID into the "term" parameter. If you pass in just an email address, the search query only finds papers with that email address in the authorids field.