### PR TITLE
Don't use global Promise object 

### DIFF
--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
@@ -78,8 +78,8 @@ function load() {
   var userGroupsP;
   var authorNotesP;
   if (!user || _.startsWith(user.id, 'guest_')) {
-    userGroupsP = Promise.resolve([]);
-    authorNotesP = Promise.resolve([]);
+    userGroupsP = $.Deferred().resolve([]);
+    authorNotesP = $.Deferred().resolve([]);
 
   } else {
     userGroupsP = Webfield.get('/groups', {member: user.id}).then(function(result) {


### PR DESCRIPTION
Currently used in ICLR webfield. It causes the page not to load in IE11