### PR TITLE
fix bad condition

### DIFF
--- a/venues/ICLR.cc/2018/Conference/python/correct-official-comment-nonreaders.py
+++ b/venues/ICLR.cc/2018/Conference/python/correct-official-comment-nonreaders.py
@@ -51,10 +51,9 @@ for n in official_comments:
     except KeyError as e:
         print n.id
         raise(e)
-    if (("ICLR.cc/2018/Conference/Reviewers_and_Higher" in n.readers or
+    if ("ICLR.cc/2018/Conference/Reviewers_and_Higher" in n.readers or
         "ICLR.cc/2018/Conference/Area_Chairs_and_Higher" in n.readers or
-        "ICLR.cc/2018/Conference/Program_Chairs" in n.readers)
-        and 'ICLR.cc/2018/Conference/Paper{number}/Authors' not in n.writers):
+        "ICLR.cc/2018/Conference/Program_Chairs" in n.readers):
 
         n.nonreaders += submission.content['authorids']
         posted_n = client.post_note(n)


### PR DESCRIPTION
Found a mistake in the correct-official-comment-nonreaders script.

I double checked, and it turns out this mistake didn't really cause any problems, and the conditional is better off being removed anyway. But I thought it was worth correcting.

(the reason it doesn't matter is because, even if the author group is a nonreader, they can read it if they are the writer of the comment)