### PR TITLE
assign nonreaders instead of appending

### DIFF
--- a/venues/ICLR.cc/2018/Conference/process/commentProcess.js
+++ b/venues/ICLR.cc/2018/Conference/process/commentProcess.js
@@ -33,13 +33,13 @@ function(){
 
       var ac_mail = {
         'groups': ['ICLR.cc/2018/Conference/Paper' + origNote.number + '/Area_Chair'],
-        'subject': 'Comment posted to a paper in your area',
+        'subject': 'Comment posted to a paper in your area. Title: ' + origNote.content.title,
         'message': 'A comment was posted to a paper for which you are serving as Area Chair.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
       var reviewer_mail = {
         'groups': ['ICLR.cc/2018/Conference/Paper' + origNote.number + '/Reviewers'],
-        'subject': 'Comment posted to a paper you are reviewing',
+        'subject': 'Comment posted to a paper you are reviewing. Title: ' + origNote.content.title,
         'message': 'A comment was posted to a paper for which you are serving as reviewer.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 

--- a/venues/ICLR.cc/2018/Conference/python/correct-official-comment-nonreaders.py
+++ b/venues/ICLR.cc/2018/Conference/python/correct-official-comment-nonreaders.py
@@ -55,7 +55,7 @@ for n in official_comments:
         "ICLR.cc/2018/Conference/Area_Chairs_and_Higher" in n.readers or
         "ICLR.cc/2018/Conference/Program_Chairs" in n.readers):
 
-        n.nonreaders += submission.content['authorids']
+        n.nonreaders = submission.content['authorids']
         posted_n = client.post_note(n)
         modified_notes.append(posted_n)
 


### PR DESCRIPTION
this is to make sure that the script can be run multiple times. it overwrites the nonreaders field of the official comments, but it's ok, because we never set this field to anything other than the authorids.