### PR TITLE
scripts and modifications to existing scripts to update the reader op…

### DIFF
--- a/venues/ICLR.cc/2018/Conference/python/config.py
+++ b/venues/ICLR.cc/2018/Conference/python/config.py
@@ -454,6 +454,7 @@ meta_review_params = {
             'values': [AREA_CHAIRS_PLUS],
             'description': 'The users who will be allowed to read the above content.'
         },
+        'nonreaders': {},
         'content': {
             'title': {
                 'order': 1,

--- a/venues/ICLR.cc/2018/Conference/python/correct-official-comment-readers.py
+++ b/venues/ICLR.cc/2018/Conference/python/correct-official-comment-readers.py
@@ -1,0 +1,68 @@
+'''
+When a reviewer posts a comment and sets the readership to
+"reviewers and higher", authors can see the comment if they
+are general conference reviewers.
+
+This script goes through the existing official comments and
+adds the author group as a nonreader, if the author group
+was not the author of the comment.
+'''
+import openreview
+import argparse
+
+## Argument handling
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base url")
+parser.add_argument('--username')
+parser.add_argument('--password')
+args = parser.parse_args()
+
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+print 'connecting to:', client.baseurl
+
+official_comments = []
+finished = False
+offset = 0
+while not finished:
+    batch = client.get_notes(invitation='ICLR.cc/2018/Conference/-/Paper.*/Official_Comment',
+                                    offset=offset, limit=2000)
+    official_comments += batch
+    if len(batch) < 2000:
+        print "len batch: ", len(batch)
+        finished = True
+    else:
+        offset += 2000
+
+blind_notes = client.get_notes(invitation='ICLR.cc/2018/Conference/-/Blind_Submission')
+
+submissions_by_forum = {n.forum: n for n in blind_notes}
+
+modified_notes = []
+for n in official_comments:
+    try:
+        submission = submissions_by_forum[n.forum]
+        note_modified = False
+
+        if "ICLR.cc/2018/Conference/Authors_and_Higher" in n.readers:
+            n.readers.remove("ICLR.cc/2018/Conference/Authors_and_Higher")
+            n.readers.append('ICLR.cc/2018/Conference/Paper{number}/Authors_and_Higher'.format(number=submission.number))
+            note_modified = True
+
+        if "ICLR.cc/2018/Conference/Reviewers_and_Higher" in n.readers:
+            n.readers.remove("ICLR.cc/2018/Conference/Reviewers_and_Higher")
+            n.readers.append('ICLR.cc/2018/Conference/Paper{number}/Reviewers_and_Higher'.format(number=submission.number))
+            note_modified = True
+
+        if "ICLR.cc/2018/Conference/Area_Chairs_and_Higher" in n.readers:
+            n.readers.remove("ICLR.cc/2018/Conference/Area_Chairs_and_Higher")
+            n.readers.append('ICLR.cc/2018/Conference/Paper{number}/Area_Chairs_and_Higher'.format(number=submission.number))
+            note_modified = True
+
+        if note_modified:
+            posted_n = client.post_note(n)
+            modified_notes.append(posted_n)
+
+    except KeyError as e:
+        print 'paper with comment id = {note_id} has been deleted'.format(note_id=n.id)
+
+print 'modified {number} official comments'.format(number=len(modified_notes))

--- a/venues/ICLR.cc/2018/Conference/python/create-comment-reader-groups.py
+++ b/venues/ICLR.cc/2018/Conference/python/create-comment-reader-groups.py
@@ -1,0 +1,72 @@
+'''
+Creates paper-specific ".*_and_Higher" groups.
+
+This is to restrict readership of private comments (e.g. those intended
+for Authors_and_Higher, Reviewers_and_Higher, or Area_Chairs_and_Higher)
+to the roles of the specific paper, not of the general conference.
+
+For example: before the change, a comment with readership of
+"Reviewers_and_Higher" would be readable by all ICLR 2018 reviewers. Now,
+it will be only readable by the reviewers for the specific paper.
+
+This solves the problem where an author who is also a global ICLR 2018
+reviewer is able to see comments on his/her own papers intended for
+"Reviewers_and_Higher".
+'''
+
+import openreview
+import argparse
+
+## Argument handling
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base url")
+parser.add_argument('--username')
+parser.add_argument('--password')
+args = parser.parse_args()
+
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+print 'connecting to:', client.baseurl
+
+blind_submissions = client.get_notes(invitation='ICLR.cc/2018/Conference/-/Blind_Submission')
+for n in blind_submissions:
+    print n.number
+    authors_and_higher = client.post_group(openreview.Group(**{
+            'id': 'ICLR.cc/2018/Conference/Paper{number}/Authors_and_Higher'.format(number=n.number),
+            'readers': ['ICLR.cc/2018/Conference'],
+            'writers': ['ICLR.cc/2018/Conference'],
+            'signatures': ['ICLR.cc/2018/Conference','~Super_User1'],
+            'signatories': [],
+            'members': [
+                'ICLR.cc/2018/Conference/Paper{number}/Authors'.format(number=n.number),
+                'ICLR.cc/2018/Conference/Paper{number}/Reviewers'.format(number=n.number),
+                'ICLR.cc/2018/Conference/Paper{number}/Area_Chair'.format(number=n.number),
+                'ICLR.cc/2018/Conference/Program_Chairs',
+                'ICLR.cc/2018/Conference'
+            ]
+        }))
+    reviewers_and_higher = client.post_group(openreview.Group(**{
+            'id': 'ICLR.cc/2018/Conference/Paper{number}/Reviewers_and_Higher'.format(number=n.number),
+            'readers': ['ICLR.cc/2018/Conference'],
+            'writers': ['ICLR.cc/2018/Conference'],
+            'signatures': ['ICLR.cc/2018/Conference','~Super_User1'],
+            'signatories': [],
+            'members': [
+                'ICLR.cc/2018/Conference/Paper{number}/Reviewers'.format(number=n.number),
+                'ICLR.cc/2018/Conference/Paper{number}/Area_Chair'.format(number=n.number),
+                'ICLR.cc/2018/Conference/Program_Chairs',
+                'ICLR.cc/2018/Conference'
+            ]
+        }))
+
+    acs_and_higher = client.post_group(openreview.Group(**{
+            'id': 'ICLR.cc/2018/Conference/Paper{number}/Area_Chairs_and_Higher'.format(number=n.number),
+            'readers': ['ICLR.cc/2018/Conference'],
+            'writers': ['ICLR.cc/2018/Conference'],
+            'signatures': ['ICLR.cc/2018/Conference','~Super_User1'],
+            'signatories': [],
+            'members': [
+                'ICLR.cc/2018/Conference/Paper{number}/Area_Chair'.format(number=n.number),
+                'ICLR.cc/2018/Conference/Program_Chairs',
+                'ICLR.cc/2018/Conference'
+            ]
+        }))

--- a/venues/ICLR.cc/2018/Conference/python/invitations.py
+++ b/venues/ICLR.cc/2018/Conference/python/invitations.py
@@ -26,6 +26,9 @@ maskAuthorsGroup = config.CONF + "/Paper[PAPER_NUMBER]/Authors"
 maskReviewerGroup = config.CONF + "/Paper[PAPER_NUMBER]/Reviewers"
 maskAreaChairGroup = config.CONF + "/Paper[PAPER_NUMBER]/Area_Chair"
 maskAnonReviewerGroup = config.CONF + "/Paper[PAPER_NUMBER]/AnonReviewer[0-9]+"
+maskAuthorsPlusGroup = config.CONF + "/Paper[PAPER_NUMBER]/Authors_and_Higher"
+maskReviewersPlusGroup = config.CONF + "/Paper[PAPER_NUMBER]/Reviewers_and_Higher"
+maskACPlusGroup = config.CONF + "/Paper[PAPER_NUMBER]/Area_Chairs_and_Higher"
 
 invitation_configurations = {
     'Add_Revision': {
@@ -41,14 +44,16 @@ invitation_configurations = {
         'byForum': True,
         'invitees': ['~'],
         'noninvitees': [maskAuthorsGroup, maskReviewerGroup, maskAreaChairGroup],
-        'params': config.public_comment_params
+        'params': config.public_comment_params,
+        'readers': ['everyone', maskAuthorsPlusGroup, maskReviewersPlusGroup, maskACPlusGroup, config.PROGRAM_CHAIRS]
     },
     'Official_Comment': {
         'byPaper': True,
         'byForum': True,
         'invitees': [maskReviewerGroup, maskAuthorsGroup, maskAreaChairGroup, config.PROGRAM_CHAIRS],
         'signatures': [maskAnonReviewerGroup, maskAuthorsGroup, maskAreaChairGroup, config.PROGRAM_CHAIRS],
-        'params': config.official_comment_params
+        'params': config.official_comment_params,
+        'readers': ['everyone', maskAuthorsPlusGroup, maskReviewersPlusGroup, maskACPlusGroup, config.PROGRAM_CHAIRS]
     },
     'Official_Review': {
         'byPaper': True,
@@ -64,7 +69,8 @@ invitation_configurations = {
         'byReplyTo': True,
         'invitees': [maskAreaChairGroup],
         'signatures': [maskAreaChairGroup],
-        'params': config.meta_review_params
+        'params': config.meta_review_params,
+        'nonreaders': [maskAuthorsGroup]
     },
     'Add_Bid': {
         'tags': True,
@@ -134,6 +140,12 @@ def get_or_create_invitations(invitationId, overwrite):
                 if 'signatures' in invitation_config:
                     new_invitation.reply['signatures']['values-regex'] = prepare_regex(new_invitation.id, invitation_config['signatures'])
                     new_invitation.reply['writers']['values-regex'] = prepare_regex(new_invitation.id, invitation_config['signatures'])
+
+                if 'readers' in invitation_config:
+                    new_invitation.reply['readers']['value-dropdown'] = prepare_invitees(new_invitation.id, invitation_config['readers'])
+
+                if 'nonreaders' in invitation_config:
+                    new_invitation.reply['nonreaders']['values'] = prepare_invitees(new_invitation.id, invitation_config['nonreaders'])
 
                 invitations.append(client.post_invitation(new_invitation))
             return invitations


### PR DESCRIPTION
…tions for public and official comments.

This PR addresses a problem with comment readership. When a commenter posts a comment with readership of "reviewers or higher", and the author of the paper is a reviewer of a different paper, then the author can actually see the comment.

We resolved this problem before by adding the author group as nonreaders to the comments where this applies, but that is not a permanent solution. With this PR, I propose we do the following:

1) we create paper-specific groups for Authors_and_Higher, Reviewers_and_Higher, and Area_Chairs_and_Higher.
2) we modify the comment invitations to accept those paper-specific values as dropdown options
3) we iterate through all comments and replace the readership with the appropriate paper-specific groups.

