### PR TITLE
add comment field, remove invitees, add readership options

### DIFF
--- a/venues/ICLR.cc/2018/Conference/python/config.py
+++ b/venues/ICLR.cc/2018/Conference/python/config.py
@@ -499,7 +499,7 @@ meta_review_params = {
 acceptance_decision_params = {
     'readers': ['everyone'],
     'writers': [CONF],
-    'invitees': [PROGRAM_CHAIRS],
+    'invitees': [],
     'signatures': [CONF],
     'reply': {
         'forum': None,
@@ -507,7 +507,7 @@ acceptance_decision_params = {
         'invitation': BLIND_SUBMISSION,
         'readers': {
             'description': 'The users who will be allowed to read the above content.',
-            'values': ['everyone']
+            'value-dropdown': ['ICLR.cc/2018/Conference/Program_Chairs', 'everyone']
         },
         'signatures': {
             'description': 'How your identity will be displayed with the above content.',
@@ -523,7 +523,7 @@ acceptance_decision_params = {
                 'required': True
             },
             'decision': {
-                'order': 3,
+                'order': 2,
                 'value-dropdown': [
                     'Accept (Oral)',
                     'Accept (Poster)',
@@ -531,7 +531,13 @@ acceptance_decision_params = {
                     'Invite to Workshop Track'
                 ],
                 'required': True
-            }
+            },
+            'comment': {
+                'order': 3,
+                'value-regex': '[\\S\\s]{1,5000}',
+                'description': '(optional) Comment on this decision.',
+                'required': False
+            },
         }
     }
 }

--- a/venues/ICLR.cc/2018/Conference/python/invitations.py
+++ b/venues/ICLR.cc/2018/Conference/python/invitations.py
@@ -76,7 +76,7 @@ invitation_configurations = {
         'byPaper': False,
         'byForum': False,
         'params': config.acceptance_decision_params,
-        'invitees': [config.PROGRAM_CHAIRS]
+        'invitees': []
     },
     'Add_Bid': {
         'tags': True,


### PR DESCRIPTION
this will allow PCs to edit the decision notes, but they aren't invitees, so they won't be able to actually post a new one. I think we should do this for two reasons: 1) it solves the problem of the invitation showing up in all the comments on every page, and 2) the performance is slow, and we don't want to encourage the PCs to click on the button if we can help it.

Also: I added two options for the readers of the notes, so that we can set the readership to just the PCs before we release it to everyone.

I deployed this on the dev site. 