### PR TITLE
update invitations.py and config.py

### DIFF
--- a/venues/ICLR.cc/2018/Workshop/python/config.py
+++ b/venues/ICLR.cc/2018/Workshop/python/config.py
@@ -256,7 +256,7 @@ public_comment_params = {
     'readers': ['everyone'],
     'writers': [CONF],
     'invitees': [],
-    'noninvitees': [REVIEWERS, AUTHORS, PROGRAM_CHAIRS],
+    'noninvitees': [REVIEWERS, PROGRAM_CHAIRS],
     'signatures': [CONF],
     'process': os.path.join(os.path.dirname(__file__), '../process/commentProcess.js'),
     'reply': {
@@ -264,7 +264,8 @@ public_comment_params = {
         'replyto': None,
         'readers': {
             'description': 'The users who will be allowed to read the above content.',
-            'value-dropdown': ['everyone', AUTHORS_PLUS, REVIEWERS_PLUS, PROGRAM_CHAIRS]
+            #'value-dropdown': ['everyone', AUTHORS_PLUS, REVIEWERS_PLUS, PROGRAM_CHAIRS],
+            'value-dropdown': ['everyone']
         },
         'signatures': {
             'description': 'How your identity will be displayed with the above content.',

--- a/venues/ICLR.cc/2018/Workshop/python/invitations.py
+++ b/venues/ICLR.cc/2018/Workshop/python/invitations.py
@@ -39,7 +39,7 @@ invitation_configurations = {
         'byPaper': True,
         'byForum': True,
         'invitees': ['~'],
-        'noninvitees': [maskAuthorsGroup, maskReviewerGroup],
+        'noninvitees': [maskReviewerGroup],
         'params': config.public_comment_params
     },
     'Official_Comment': {


### PR DESCRIPTION
makes public comments readable by "everyone" with no other options.

Leaving the commented parameters in there because this is a temporary fix. I would like to merge it, though, so that the latest record of what is actually implemented on the live site is in master.