### PR TITLE
Override submission default messages for authors and authorids

### DIFF
--- a/venues/swsa.semanticweb.org/ISWC/2018/DeSemWeb/python/init-submissions.py
+++ b/venues/swsa.semanticweb.org/ISWC/2018/DeSemWeb/python/init-submissions.py
@@ -70,6 +70,18 @@ submission_inv = invitations.Submission(
     conference_id = js_constants['CONFERENCE'],
     duedate = DUE_DATE,
     content_params = {
+        'authors': {
+            'description': 'Comma separated list of author names.',
+            'order': 2,
+            'values-regex': "[^;,\\n]+(,[^,\\n]+)*",
+            'required': True
+        },
+        'authorids': {
+            'description': 'Comma separated list of author email addresses, lowercased, in the same order as above. For authors with existing OpenReview accounts, please make sure that the provided email address(es) match those listed in the author\'s profile.',
+            'order': 3,
+            'values-regex': "([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})",
+            'required': True
+        },
         "submission category": {
             "required": True,
             "order": 4,


### PR DESCRIPTION
The default submission invitation says that it will anonymize authors and authorids.  Override default for this workshop since it is not double blind.