### PR TITLE
update metadata script to include authors with no profile

### DIFF
--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata.py
@@ -63,7 +63,9 @@ def conflict(forum, user_id):
     try:
         paper = papers_by_forum[forum]
         profile = profiles_by_id[user_id]
-        return openreview.matching.get_conflicts(client.get_profiles(paper.content['authorids']), profile)
+        author_profiles = {authorid: None for authorid in paper.content['authorids']}
+        author_profiles.update(client.get_profiles(paper.content['authorids']))
+        return openreview.matching.get_conflicts(author_profiles, profile)
     except KeyError as e:
         print "conflict error!"
         print 'forum: ', forum


### PR DESCRIPTION
requires https://github.com/iesl/openreview-py/pull/93

this change makes it so that the author_profiles dict can include None as a value, if an author doesn't have a profile.