### PR TITLE
update homepage page limit

### DIFF
--- a/venues/auai.org/UAI/2018/webfield/homepage.js
+++ b/venues/auai.org/UAI/2018/webfield/homepage.js
@@ -1,6 +1,6 @@
 var SUBJECT_AREAS_LIST = [];
 var BUFFER = 1000 * 60 * 30;  // 30 minutes
-var PAGE_SIZE = 50;
+var PAGE_SIZE = 400;
 var paperDisplayOptions = {
   pdfLink: true,
   replyCount: true,


### PR DESCRIPTION
This is needed so that area chairs (and others with access to all the papers) get all papers. Without it, there is a possibility that the area chair's own submitted papers don't get included in the response.