### PR TITLE
Feature/new matching api

### DIFF
--- a/venues/auai.org/UAI/2018/python/match-areachairs.py
+++ b/venues/auai.org/UAI/2018/python/match-areachairs.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function
 import argparse
 import openreview
 import openreview_matcher
@@ -32,6 +31,7 @@ configuration_note_params = {
             'maxusers': 1,
             'minpapers': 1,
             'maxpapers': 10,
+            'alternates': 5,
             'weights': {
                 'tpms_score': 1,
                 'conflict_score': 1,
@@ -47,10 +47,12 @@ configuration_note_params = {
     }
 }
 
-config_note = openreview.matching.create_or_update_config(client, label, configuration_note_params)
+config_notes = client.get_notes(invitation='auai.org/UAI/2018/-/Assignment_Configuration')
+config_note = [c for c in config_notes if c.content['label'] == label][0]
+config_note = openreview.Note(**dict(config_note.to_json(), **configuration_note_params))
 posted_config = client.post_note(config_note)
 
-assignments = openreview.matching.match(client, posted_config, openreview_matcher.Solver)
+assignments = openreview_matcher.match(client, posted_config)
 
 for n in assignments:
     print "posting assignment for ", n.forum

--- a/venues/auai.org/UAI/2018/python/match-areachairs.py
+++ b/venues/auai.org/UAI/2018/python/match-areachairs.py
@@ -47,12 +47,9 @@ configuration_note_params = {
     }
 }
 
-config_notes = client.get_notes(invitation='auai.org/UAI/2018/-/Assignment_Configuration')
-config_note = [c for c in config_notes if c.content['label'] == label][0]
-config_note = openreview.Note(**dict(config_note.to_json(), **configuration_note_params))
-posted_config = client.post_note(config_note)
+configuration_note, assignments = openreview_matcher.match(client, configuration_note_params)
 
-assignments = openreview_matcher.match(client, posted_config)
+posted_config = client.post_note(configuration_note)
 
 for n in assignments:
     print "posting assignment for ", n.forum

--- a/venues/auai.org/UAI/2018/python/match-reviewers-constrained.py
+++ b/venues/auai.org/UAI/2018/python/match-reviewers-constrained.py
@@ -54,8 +54,6 @@ configuration_note_params = {
     }
 }
 
-config_note = openreview.matching.create_or_update_config(client, label, configuration_note_params)
-
 '''
 Add some manual constraints based on the first matching
 '''
@@ -69,11 +67,16 @@ for forum, assignment in r1_assignments_by_forum.iteritems():
     for entry in assignment.content['assignedGroups']:
         new_constraints[forum][entry['userId']] = 10.0
 
-config_note.content['constraints'] = new_constraints
 
+config_notes = [c for c in client.get_notes(invitation='auai.org/UAI/2018/-/Assignment_Configuration') if c.content['label'] == label]
+if config_notes:
+    config_note = openreview.Note(**dict(config_note[0].to_json(), **configuration_note_params))
+else:
+    config_note = openreview.Note(**configuration_note_params)
+config_note.content['constraints'] = new_constraints
 posted_config = client.post_note(config_note)
 
-assignments = openreview.matching.match(client, posted_config, openreview_matcher.Solver)
+assignments = openreview_matcher.match(client, posted_config, openreview_matcher.Solver)
 
 for n in assignments:
     print("posting assignment for ", n.forum)

--- a/venues/auai.org/UAI/2018/python/match-reviewers.py
+++ b/venues/auai.org/UAI/2018/python/match-reviewers.py
@@ -59,7 +59,7 @@ config_note = [c for c in config_notes if c.content['label'] == label][0]
 config_note = openreview.Note(**dict(config_note.to_json(), **configuration_note_params))
 posted_config = client.post_note(config_note)
 
-assignments = openreview.matching.match(client, posted_config, openreview_matcher.Solver)
+assignments = openreview_matcher.match(client, posted_config, openreview_matcher.Solver)
 
 for n in assignments:
     print("posting assignment for ", n.forum)

--- a/venues/auai.org/UAI/2018/python/match-reviewers.py
+++ b/venues/auai.org/UAI/2018/python/match-reviewers.py
@@ -54,7 +54,9 @@ configuration_note_params = {
     }
 }
 
-config_note = openreview.matching.create_or_update_config(client, label, configuration_note_params)
+config_notes = client.get_notes(invitation='auai.org/UAI/2018/-/Assignment_Configuration')
+config_note = [c for c in config_notes if c.content['label'] == label][0]
+config_note = openreview.Note(**dict(config_note.to_json(), **configuration_note_params))
 posted_config = client.post_note(config_note)
 
 assignments = openreview.matching.match(client, posted_config, openreview_matcher.Solver)

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/download-reviewer-profiles.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/download-reviewer-profiles.py
@@ -1,0 +1,57 @@
+import openreview
+import random
+import argparse
+import requests
+from collections import defaultdict
+import csv
+import os
+import pickle
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base URL")
+parser.add_argument('--username')
+parser.add_argument('--password')
+
+args = parser.parse_args()
+
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+print 'connecting to {0}'.format(client.baseurl)
+
+papers = openreview.tools.get_all_notes(client, 'cv-foundation.org/ECCV/2018/Conference/-/Submission')
+papers_by_forum = {}
+forum_by_paperId = {}
+for p in papers:
+    papers_by_forum[p.forum] = p
+    forum_by_paperId[p.content['paperId']] = p.forum
+
+profiles_by_email = {}
+
+#Load CMT conflicts
+cmt_conflicts = defaultdict(list)
+with open('../data/reviewer-conflicts.csv') as f:
+    reader = csv.reader(f)
+    reader.next()
+    for line in reader:
+        email = line[2].strip().lower()
+        paperid = line[3].strip().lower()
+        if paperid in forum_by_paperId:
+            conflicted_forum = forum_by_paperId[paperid]
+            if not email in profiles_by_email:
+                print "getting profile: ", email
+                new_profiles = client.get_profiles([email])
+                if not new_profiles:
+                    profiles_by_email.update({email: None})
+                else:
+                    profiles_by_email.update(new_profiles)
+
+            if email in profiles_by_email and profiles_by_email[email]:
+                userid = profiles_by_email[email].id
+            else:
+                print "no profile found while updating CMT conflicts: ", email
+            if userid:
+                cmt_conflicts[conflicted_forum].append(userid)
+        else:
+            print "couldn't find paper with id ", paperid
+
+with open('../data/cmt_conflicts.pkl', 'wb') as f:
+    pickle.dump(cmt_conflicts, f)

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/match-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/match-reviewers.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+import argparse
+import openreview
+import openreview_matcher
+
+# Argument handling
+parser = argparse.ArgumentParser()
+parser.add_argument('--label', required=True)
+parser.add_argument('--username')
+parser.add_argument('--password')
+parser.add_argument('--baseurl', help="base URL")
+args = parser.parse_args()
+
+client = openreview.Client(username=args.username, password=args.password, baseurl=args.baseurl)
+
+print("connecting to {}".format(client.baseurl))
+
+config_note = openreview.Note(**{
+    'invitation': 'cv-foundation.org/ECCV/2018/Conference/-/Assignment_Configuration',
+    'readers': [
+        'cv-foundation.org/ECCV/2018/Conference',
+        'cv-foundation.org/ECCV/2018/Conference/Program_Chairs'
+    ],
+    'writers': ['cv-foundation.org/ECCV/2018/Conference'],
+    'signatures': ['cv-foundation.org/ECCV/2018/Conference'],
+    'content': {
+        'label': args.label,
+        'configuration': {
+            'minusers': 3,
+            'maxusers': 3,
+            'minpapers': 0,
+            'maxpapers': 8,
+            'alternates': 5,
+            'weights': {
+                'tpms_score': 1,
+                'conflict_score': 1
+            }
+        },
+        #'constraints': {}, # manually-added constraints are not supported yet
+        'paper_invitation': 'cv-foundation.org/ECCV/2018/Conference/-/Submission',
+        'metadata_invitation': 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Metadata/Reviewers',
+        'assignment_invitation': 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Assignment',
+        'match_group': 'cv-foundation.org/ECCV/2018/Conference/Reviewers',
+        'status': 'complete' # 'queued', 'processing', 'complete' or 'error'
+    }
+})
+
+assignments = openreview_matcher.match(client, config_note)

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/match-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/match-reviewers.py
@@ -39,7 +39,7 @@ config_note = openreview.Note(**{
         },
         #'constraints': {}, # manually-added constraints are not supported yet
         'paper_invitation': 'cv-foundation.org/ECCV/2018/Conference/-/Submission',
-        'metadata_invitation': 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Metadata/Reviewers',
+        'metadata_invitation': 'cv-foundation.org/ECCV/2018/Conference/Reviewers/-/Paper_Metadata',
         'assignment_invitation': 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Assignment',
         'match_group': 'cv-foundation.org/ECCV/2018/Conference/Reviewers',
         'status': 'complete' # 'queued', 'processing', 'complete' or 'error'

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-matching.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-matching.py
@@ -36,7 +36,7 @@ metadata_inv = client.post_invitation(openreview.Invitation(**{
 }))
 
 metadata_reviewers_inv = client.post_invitation(openreview.Invitation(**{
-    'id': 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Metadata/Reviewers',
+    'id': 'cv-foundation.org/ECCV/2018/Conference/Reviewers/-/Paper_Metadata',
     'readers': [
         'cv-foundation.org/ECCV/2018/Conference',
         'cv-foundation.org/ECCV/2018/Conference/Program_Chairs'

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-matching.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-matching.py
@@ -35,6 +35,28 @@ metadata_inv = client.post_invitation(openreview.Invitation(**{
     }
 }))
 
+metadata_reviewers_inv = client.post_invitation(openreview.Invitation(**{
+    'id': 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Metadata/Reviewers',
+    'readers': [
+        'cv-foundation.org/ECCV/2018/Conference',
+        'cv-foundation.org/ECCV/2018/Conference/Program_Chairs'
+    ],
+    'writers': ['cv-foundation.org/ECCV/2018/Conference'],
+    'signatures': ['cv-foundation.org/ECCV/2018/Conference'],
+    'reply': {
+        'forum': None,
+        'replyto': None,
+        'invitation': 'cv-foundation.org/ECCV/2018/Conference/-/Submission',
+        'readers': {'values': [
+            'cv-foundation.org/ECCV/2018/Conference',
+            'cv-foundation.org/ECCV/2018/Conference/Program_Chairs'
+            ]},
+        'writers': {'values': ['cv-foundation.org/ECCV/2018/Conference']},
+        'signatures': {'values': ['cv-foundation.org/ECCV/2018/Conference']},
+        'content': {}
+    }
+}))
+
 
 print "posting assignment invitation..."
 assignment_inv = client.post_invitation(openreview.Invitation(**{

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
@@ -25,27 +25,28 @@ group_ids = [
 metadata_invitation = 'cv-foundation.org/ECCV/2018/Conference/Reviewers/-/Paper_Metadata'
 
 #Load Papers
-print "getting all submissions..."
+print "getting all submissions...",
 papers = openreview.tools.get_all_notes(client, 'cv-foundation.org/ECCV/2018/Conference/-/Submission')
 papers_by_forum = {}
 forum_by_paperId = {}
 for p in papers:
     papers_by_forum[p.forum] = p
     forum_by_paperId[p.content['paperId']] = p.forum
+print "done."
 
 #Load group profiles
-print "getting groups..."
+print "getting groups...",
 groups = [client.get_group(g) for g in group_ids]
 profiles_by_id = {}
 for g in groups:
     profiles_by_id.update({profile.id: profile for profile in client.get_profiles(g.members)})
+print "done."
 
 #Load TPMS scores
-print "loading tpms scores from file..."
-tpms_scores = defaultdict(list)
-scores_by_email = {}
-
-with open(os.path.join(os.path.dirname(__file__), '../data/reviewers_scores.csv')) as f:
+print "loading tpms scores from file...",
+scores_by_forum = {}
+ids_by_email = {}
+with open('../data/reviewers_scores.csv') as f:
     reader = csv.reader(f)
     reader.next()
     for line in reader:
@@ -53,110 +54,94 @@ with open(os.path.join(os.path.dirname(__file__), '../data/reviewers_scores.csv'
         email = line[1].strip().lower()
         score = line[2].strip()
 
-        if email not in scores_by_email:
-            scores_by_email[email] = {}
+        forum = forum_by_paperId.get(paperId, '')
 
-        forum = forum_by_paperId.get(paperId, 0)
+        if forum not in scores_by_forum:
+            scores_by_forum[forum] = {}
 
-        scores_by_email[email][forum] = float(score)
-
-    #translate emails to ids
-    for k,v in scores_by_email.iteritems():
-        profiles = client.get_profiles([k])
-        if profiles:
-            tpms_scores[profiles[k].id] = v
+        if email not in ids_by_email:
+            profiles = client.get_profiles([email])
+            if profiles:
+                userid = profiles[email].id
+            else:
+                userid = None
+            ids_by_email[email] = userid
         else:
-            'Profile not found', k
+            userid = ids_by_email[email]
+
+        if userid:
+            scores_by_forum[forum][userid] = float(score)
+print "done."
 
 #Load author profiles
-print "loading author profiles from file..."
+print "loading author profiles from file...",
 author_profiles_by_email = {}
 with open('../data/profiles.pkl', 'rb') as f:
     author_profiles_by_email = pickle.load(f)
+print "done."
 
 #Load CMT conflicts
-print "loading CMT conflicts"
+print "loading CMT conflicts...",
 cmt_conflicts = {}
-with open('../data/cmt_conflicts.pkl','rb') as f:
-    cmt_conflicts = pickle.load(f)
+profiles_by_email = {}
+with open('../data/reviewer-conflicts.csv') as f:
+    reader = csv.reader(f)
+    reader.next()
+    for line in reader:
+        email = line[2].strip().lower()
+        paperid = line[3].strip().lower()
+        if paperid in forum_by_paperId:
+            conflicted_forum = forum_by_paperId[paperid]
+            if not email in profiles_by_email:
+                #print "getting profile: ", email
+                new_profiles = client.get_profiles([email])
+                if not new_profiles:
+                    profiles_by_email.update({email: None})
+                else:
+                    profiles_by_email.update(new_profiles)
 
-def conflict(forum, user_id):
-    try:
-        paper = papers_by_forum[forum]
-        profile = profiles_by_id[user_id]
-        author_profiles = {}
-        for authorid in paper.content['authorids']:
-            author_profiles[authorid] = author_profiles_by_email.get(authorid, None)
-        return openreview.matching.get_conflicts(author_profiles, profile)
-    except KeyError as e:
-        print "conflict error!"
-        print 'forum: ', forum
-        return []
+            if email in profiles_by_email and profiles_by_email[email]:
+                userid = profiles_by_email[email].id
+            else:
+                #print "no profile found while updating CMT conflicts: ", email
+                pass
+            if userid:
+                cmt_conflicts[conflicted_forum] = cmt_conflicts.get(conflicted_forum, {})
+                cmt_conflicts[conflicted_forum][userid] = '-inf'
+print "done."
 
-def tpms(forum, user_id):
-    if forum in tpms_scores[user_id]:
-        return tpms_scores[user_id][forum]
-    else:
-        print 'Score not found', forum, user_id
-        return 0.0
-
-
-def metadata(forum, groups):
-    metadata_params = {
-        'forum': forum,
-        'invitation': metadata_invitation,
-        'readers': [
-            'cv-foundation.org/ECCV/2018/Conference',
-            'cv-foundation.org/ECCV/2018/Conference/Program_Chairs'
-        ],
-        'writers': ['cv-foundation.org/ECCV/2018/Conference'],
-        'signatures': ['cv-foundation.org/ECCV/2018/Conference'],
-        'content': {
-            'groups': {}
-        }
-    }
-
-    forum_cmt_conflicts = cmt_conflicts[forum]
-
+# load openreview conflicts
+print "loading openreview conflicts...",
+openreview_conflicts = {}
+for forum, paper in papers_by_forum.iteritems():
+    forum_conflicts = {}
     for g in groups:
-
-        group_entry = []
         for user_id in g.members:
-            if '~' in user_id:
-                user_entry = {'userId': user_id, 'scores': {}}
-                tpms_score = tpms(forum, user_id)
-                conflicts = conflict(forum, user_id)
+            profile = profiles_by_id[user_id]
+            author_profiles = {}
+            for authorid in paper.content['authorids']:
+                author_profiles[authorid] = author_profiles_by_email.get(authorid, None)
+            conflicts = openreview.matching.get_conflicts(author_profiles, profile)
+            if conflicts:
+                forum_conflicts[user_id] = '-inf'
+
+    openreview_conflicts[forum] = forum_conflicts
+print "done."
+
+new_metadata_notes = openreview_matcher.metadata.generate_metadata_notes(client, config_note,
+    score_maps = {
+        'tpmsScore': scores_by_forum,
+    },
+    constraint_maps = {
+        'cmtConflict': cmt_conflicts,
+        'openreviewConflict': openreview_conflicts
+    }
+)
+
+for m in new_metadata_notes:
+    new_m = client.post_note(m)
+    print new_m.id
 
 
-                if conflicts:
-                    user_entry['scores']['conflict_score'] = '-inf'
-                    user_entry['conflicts'] = conflicts
-                if tpms_score > 0:
-                    user_entry['scores']['tpms_score'] = tpms_score
 
-                if user_id in forum_cmt_conflicts:
-                    user_entry['scores']['conflict_score'] = '-inf'
-                    if 'conflicts' not in user_entry:
-                        user_entry['conflicts'] = ['CMT_conflict']
-                    else:
-                        user_entry['conflicts'].append('CMT_conflict')
 
-                group_entry.append(user_entry)
-
-        metadata_params['content']['groups'][g.id] = group_entry
-
-    return metadata_params
-
-print "getting existing metadata notes..."
-existing_notes_by_forum = {n.forum: n for n in openreview.tools.get_all_notes(client, metadata_invitation)}
-
-print "updating paper metadata..."
-for p in papers:
-    if p.forum in existing_notes_by_forum:
-        metadata_params = existing_notes_by_forum[p.forum].to_json()
-    else:
-        metadata_params = {}
-
-    metadata_params.update(metadata(p.forum, groups))
-    metadata_note = client.post_note(openreview.Note(**metadata_params))
-    print metadata_note.id

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
@@ -44,8 +44,8 @@ for g in groups:
 print "loading tpms scores from file..."
 tpms_scores = defaultdict(list)
 scores_by_email = {}
-file = '../data/reviewers_scores.csv'
-with open(os.path.join(os.path.dirname(__file__), file)) as f:
+
+with open(os.path.join(os.path.dirname(__file__), '../data/reviewers_scores.csv')) as f:
     reader = csv.reader(f)
     reader.next()
     for line in reader:
@@ -75,24 +75,10 @@ with open('../data/profiles.pkl', 'rb') as f:
     author_profiles_by_email = pickle.load(f)
 
 #Load CMT conflicts
-cmt_conflicts = defaultdict(list)
-with open('../data/reviewer-conflicts.csv') as f:
-    reader = csv.reader(f)
-    reader.next()
-    for line in reader:
-        email = line[2].strip().lower()
-        paperid = line[3].strip().lower()
-        if paperid in forum_by_paperId:
-            conflicted_forum = forum_by_paperId[paperid]
-            profiles = client.get_profiles([email])
-            if profiles:
-                userid = profiles[email].id
-            else:
-                print "no profile found while updating CMT conflicts: ", email
-            if userid:
-                cmt_conflicts[conflicted_forum].append(userid)
-        else:
-            print "couldn't find paper with id ", paperid
+print "loading CMT conflicts"
+cmt_conflicts = {}
+with open('../data/cmt_conflicts.pkl','rb') as f:
+    cmt_conflicts = pickle.load(f)
 
 def conflict(forum, user_id):
     try:

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
@@ -1,0 +1,176 @@
+import openreview
+import random
+import argparse
+import requests
+from collections import defaultdict
+import csv
+import os
+import json
+import pickle
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base URL")
+parser.add_argument('--username')
+parser.add_argument('--password')
+
+args = parser.parse_args()
+
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+print 'connecting to {0}'.format(client.baseurl)
+
+group_ids = [
+    'cv-foundation.org/ECCV/2018/Conference/Reviewers'
+]
+
+metadata_invitation = 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Metadata/Reviewers'
+
+#Load Papers
+print "getting all submissions..."
+papers = openreview.tools.get_all_notes(client, 'cv-foundation.org/ECCV/2018/Conference/-/Submission')
+papers_by_forum = {}
+forum_by_paperId = {}
+for p in papers:
+    papers_by_forum[p.forum] = p
+    forum_by_paperId[p.content['paperId']] = p.forum
+
+#Load group profiles
+print "getting groups..."
+groups = [client.get_group(g) for g in group_ids]
+profiles_by_id = {}
+for g in groups:
+    profiles_by_id.update({profile.id: profile for profile in client.get_profiles(g.members)})
+
+#Load TPMS scores
+print "loading tpms scores from file..."
+tpms_scores = defaultdict(list)
+scores_by_email = {}
+file = '../data/reviewers_scores.csv'
+with open(os.path.join(os.path.dirname(__file__), file)) as f:
+    reader = csv.reader(f)
+    reader.next()
+    for line in reader:
+        paperId = line[0].strip()
+        email = line[1].strip().lower()
+        score = line[2].strip()
+
+        if email not in scores_by_email:
+            scores_by_email[email] = {}
+
+        forum = forum_by_paperId.get(paperId, 0)
+
+        scores_by_email[email][forum] = float(score)
+
+    #translate emails to ids
+    for k,v in scores_by_email.iteritems():
+        profiles = client.get_profiles([k])
+        if profiles:
+            tpms_scores[profiles[k].id] = v
+        else:
+            'Profile not found', k
+
+#Load author profiles
+print "loading author profiles from file..."
+author_profiles_by_email = {}
+with open('../data/profiles.pkl', 'rb') as f:
+    author_profiles_by_email = pickle.load(f)
+
+#Load CMT conflicts
+cmt_conflicts = defaultdict(list)
+with open('../data/reviewer-conflicts.csv') as f:
+    reader = csv.reader(f)
+    reader.next()
+    for line in reader:
+        email = line[2].strip().lower()
+        paperid = line[3].strip().lower()
+        if paperid in forum_by_paperId:
+            conflicted_forum = forum_by_paperId[paperid]
+            profiles = client.get_profiles([email])
+            if profiles:
+                userid = profiles[email].id
+            else:
+                print "no profile found while updating CMT conflicts: ", email
+            if userid:
+                cmt_conflicts[conflicted_forum].append(userid)
+        else:
+            print "couldn't find paper with id ", paperid
+
+def conflict(forum, user_id):
+    try:
+        paper = papers_by_forum[forum]
+        profile = profiles_by_id[user_id]
+        author_profiles = {}
+        for authorid in paper.content['authorids']:
+            author_profiles[authorid] = author_profiles_by_email.get(authorid, None)
+        return openreview.matching.get_conflicts(author_profiles, profile)
+    except KeyError as e:
+        print "conflict error!"
+        print 'forum: ', forum
+        return []
+
+def tpms(forum, user_id):
+    if forum in tpms_scores[user_id]:
+        return tpms_scores[user_id][forum]
+    else:
+        print 'Score not found', forum, user_id
+        return 0.0
+
+
+def metadata(forum, groups):
+    metadata_params = {
+        'forum': forum,
+        'invitation': metadata_invitation,
+        'readers': [
+            'cv-foundation.org/ECCV/2018/Conference',
+            'cv-foundation.org/ECCV/2018/Conference/Program_Chairs'
+        ],
+        'writers': ['cv-foundation.org/ECCV/2018/Conference'],
+        'signatures': ['cv-foundation.org/ECCV/2018/Conference'],
+        'content': {
+            'groups': {}
+        }
+    }
+
+    forum_cmt_conflicts = cmt_conflicts[forum]
+
+    for g in groups:
+
+        group_entry = []
+        for user_id in g.members:
+            if '~' in user_id:
+                user_entry = {'userId': user_id, 'scores': {}}
+                tpms_score = tpms(forum, user_id)
+                conflicts = conflict(forum, user_id)
+
+
+                if conflicts:
+                    user_entry['scores']['conflict_score'] = '-inf'
+                    user_entry['conflicts'] = conflicts
+                if tpms_score > 0:
+                    user_entry['scores']['tpms_score'] = tpms_score
+
+                if user_id in forum_cmt_conflicts:
+                    user_entry['scores']['conflict_score'] = '-inf'
+                    if 'conflicts' not in user_entry:
+                        user_entry['conflicts'] = ['CMT_conflict']
+                    else:
+                        user_entry['conflicts'].append('CMT_conflict')
+
+                group_entry.append(user_entry)
+
+        metadata_params['content']['groups'][g.id] = group_entry
+
+    return metadata_params
+
+print "getting existing metadata notes..."
+existing_notes_by_forum = {n.forum: n for n in openreview.tools.get_all_notes(client, metadata_invitation)}
+
+print "updating paper metadata..."
+for p in papers:
+    if p.forum in existing_notes_by_forum:
+        metadata_params = existing_notes_by_forum[p.forum].to_json()
+    else:
+        metadata_params = {}
+
+    metadata_params.update(metadata(p.forum, groups))
+    metadata_note = client.post_note(openreview.Note(**metadata_params))
+    print metadata_note.id

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
@@ -22,7 +22,7 @@ group_ids = [
     'cv-foundation.org/ECCV/2018/Conference/Reviewers'
 ]
 
-metadata_invitation = 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Metadata/Reviewers'
+metadata_invitation = 'cv-foundation.org/ECCV/2018/Conference/Reviewers/-/Paper_Metadata'
 
 #Load Papers
 print "getting all submissions..."

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/upload-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/upload-reviewers.py
@@ -1,0 +1,69 @@
+import openreview
+import argparse
+import csv
+import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base URL")
+parser.add_argument('--username')
+parser.add_argument('--password')
+args = parser.parse_args()
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+
+
+def search_institution(history, domain):
+    for h in history:
+        if domain == h['institution']['domain']:
+            return True
+    return False
+
+with open(os.path.join(os.path.dirname(__file__),'../data/reviewers.csv')) as f:
+    reader = csv.reader(f)
+    reader.next()
+    members = []
+    for line in reader:
+        first = line[0].strip()
+        middle = line[1].strip()
+        last = line[2].strip()
+        email = line[3].lower().strip()
+        if len(line) > 5:
+            conflicts = [c.strip() for c in line[5].lower().strip().split(';')]
+        else:
+            conflicts = []
+
+        profiles = client.get_profiles([email])
+
+        if profiles:
+            profile_note = client.get_note(id = profiles[email].id)
+
+            history = profile_note.content.get('history', [])
+
+            for c in conflicts:
+                exists = search_institution(history, c)
+                if not exists:
+                    history.append({
+                        'end': None,
+                        'start': None,
+                        'position': None,
+                        'institution': {
+                            'name': c,
+                            'domain': c
+                        }
+                    })
+            profile_note.content['history'] = history
+
+            saved_profile = client.update_profile(profile_note.id, profile_note.content)
+            members.append(saved_profile.id)
+        else:
+            print 'Not Found', email
+
+reviewers_group = client.post_group(openreview.Group(**{
+    'id': 'cv-foundation.org/ECCV/2018/Conference/Reviewers',
+    'readers': ['everyone'],
+    'writers': [],
+    'signatures': ['~Super_User1'],
+    'signatories': [],
+    'members': members
+}))
+
+print reviewers_group.members


### PR DESCRIPTION
How to match ECCV reviewers:

1. Ensure that all researcher profiles that we know about have equivalent profiles in OpenReview.
2. Run upload-reviewers.py. This will:
- Detect any missing profiles (there should be none, when we run this in the real conference)
- Create the cv-foundation.org/ECCV/2018/Conference/Reviewers group
3. Run setup-matching.py. This will create the new, reviewer-specific metadata invitation.
4. Run download-profiles.py to get the profiles.pkl file
5. Run download-reviewer_profiles.py to get the cmt_conflicts.pkl file
5. Run setup-metadata-reviewers.py. This will generate the metadata required to do the match.
6. Run match-reviewers.py. Make sure to adjust the configuration directly in the file, if necessary

