### PR TITLE
refactor reviewer match sequence

### DIFF
--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/cmt-dump.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/cmt-dump.py
@@ -11,6 +11,7 @@ datestring = '{:0>4}-{:0>2}-{:0>2}'.format(now.year, now.month, now.day)
 
 # Argument handling
 parser = argparse.ArgumentParser()
+parser.add_argument('--label', required=True)
 parser.add_argument('-o','--outfile', default = '../data/{}-cmt-dump.xml'.format(datestring))
 parser.add_argument('-i','--infile', default='../data/areachairs.csv')
 parser.add_argument('--username')
@@ -37,7 +38,8 @@ def indent(elem, level=0):
 
 print "collecting data from {}".format(client.baseurl)
 papers = openreview.tools.get_all_notes(client, 'cv-foundation.org/ECCV/2018/Conference/-/Submission')
-assignments = openreview.tools.get_all_notes(client, 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Assignment')
+all_assignments = openreview.tools.get_all_notes(client, 'cv-foundation.org/ECCV/2018/Conference/-/Paper_Assignment')
+assignments = [a for a in all_assignments if a.content['label'] == args.label]
 assignment_by_forum = {n.forum: n for n in assignments}
 
 print "reading emails from {}".format(args.infile)

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/download-areachair-profiles.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/download-areachair-profiles.py
@@ -27,7 +27,7 @@ for p in papers:
 profiles_by_email = {}
 
 #Load CMT conflicts
-with open('../data/reviewers.csv') as f:
+with open('../data/areachairs.csv') as f:
     reader = csv.reader(f)
     reader.next()
     for line in reader:
@@ -44,5 +44,5 @@ with open('../data/reviewers.csv') as f:
             else:
                 profiles_by_email.update(new_profiles)
 
-with open('../data/reviewer-profiles.pkl', 'wb') as f:
+with open('../data/areachair-profiles.pkl', 'wb') as f:
     pickle.dump(profiles_by_email, f)

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/download-author-profiles.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/download-author-profiles.py
@@ -26,7 +26,7 @@ for paper in papers:
     paper_profiles = client.get_profiles(authorids)
     profiles_by_email.update(paper_profiles)
 
-with open('../data/profiles.pkl', 'wb') as f:
+with open('../data/author-profiles.pkl', 'wb') as f:
     pickle.dump(profiles_by_email, f)
 
 

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/download-reviewer-profiles.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/download-reviewer-profiles.py
@@ -42,7 +42,9 @@ with open('../data/reviewers.csv') as f:
             if not new_profiles:
                 profiles_by_email.update({email: None})
             else:
-                profiles_by_email.update(new_profiles)
+                profile = new_profiles[email]
+                new_email_entries = {e: profile for e in profile.content['emails']}
+                profiles_by_email.update(new_email_entries)
 
 with open('../data/reviewer-profiles.pkl', 'wb') as f:
     pickle.dump(profiles_by_email, f)

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/download-score-maps.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/download-score-maps.py
@@ -1,0 +1,158 @@
+import openreview
+import openreview_matcher
+import random
+import argparse
+import requests
+from collections import defaultdict
+import csv
+import os
+import json
+import pickle
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base URL")
+parser.add_argument('--username')
+parser.add_argument('--password')
+
+args = parser.parse_args()
+
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+print 'connecting to {0}'.format(client.baseurl)
+
+#Network calls
+print "getting all submissions...",
+metadata_invitation = client.get_invitation('cv-foundation.org/ECCV/2018/Conference/Reviewers/-/Paper_Metadata')
+reviewers = client.get_group('cv-foundation.org/ECCV/2018/Conference/Reviewers')
+papers = openreview.tools.get_all_notes(client, 'cv-foundation.org/ECCV/2018/Conference/-/Submission')
+papers_by_forum = {}
+forum_by_paperid = {}
+for p in papers:
+    papers_by_forum[p.forum] = p
+    forum_by_paperid[p.content['paperId']] = p.forum
+
+#Load saved profiles:
+print "loading author profiles from file..."
+author_profiles_by_email = {}
+with open('../data/author-profiles.pkl', 'rb') as f:
+    author_profiles_by_email = pickle.load(f)
+
+print "loading reviewer profiles from file..."
+reviewer_profiles_by_email = {}
+with open('../data/reviewer-profiles.pkl', 'rb') as f:
+    reviewer_profiles_by_email = pickle.load(f)
+
+reviewer_profiles_by_id = {profile.id: profile for profile in reviewer_profiles_by_email.values()}
+
+#Load TPMS scores
+print "loading tpms scores from file..."
+scores_by_forum = {}
+with open('../data/reviewers_scores.csv') as f:
+    reader = csv.reader(f)
+    reader.next()
+    for line in reader:
+        paperId = line[0].strip()
+        email = line[1].strip().lower()
+        score = line[2].strip()
+
+        forum = forum_by_paperid.get(paperId)
+
+        if forum:
+            if forum not in scores_by_forum:
+                scores_by_forum[forum] = {}
+
+            profile = reviewer_profiles_by_email.get(email)
+
+            if profile:
+                scores_by_forum[forum][profile.id] = float(score)
+            else:
+                print "profile not found: ", email
+
+#Load AC ranks
+print "loading ac ranks from file..."
+ac_rank_by_forum = {}
+max_rank = 0
+with open('../data/ac-recommendations-2018-04-07.csv') as f:
+    reader = csv.reader(f)
+    for row in reader:
+        ac_email = row[0].lower().strip()
+        paper_id = row[1]
+        ac_rank = int(row[2])
+        reviewer_email = row[3].lower().strip()
+
+        reviewer_profile = reviewer_profiles_by_email.get(reviewer_email)
+        paper_forum = forum_by_paperid.get(paper_id)
+
+        if paper_forum not in ac_rank_by_forum:
+            ac_rank_by_forum[paper_forum] = {}
+
+        if reviewer_profile:
+            ac_rank_by_forum[paper_forum][reviewer_profile.id] = ac_rank
+        else:
+            print "no reviewer found for email ", reviewer_email
+
+        if ac_rank > max_rank:
+            max_rank = ac_rank
+
+print "converting to score...",
+#rank_to_score converts the rank given by the AC for a reviewer into a score in the range (0.0, 1.0]
+rank_to_score = [float(max_rank-i)/float(max_rank) for i in range(max_rank)]
+ac_score_by_forum = {}
+for forum, reviewer_ranks in ac_rank_by_forum.iteritems():
+    if forum not in ac_score_by_forum:
+        ac_score_by_forum[forum] = {}
+    for reviewer, rank in ac_rank_by_forum[forum].iteritems():
+        # rank-1 because AC ranks starts at index 1, and rank_to_score starts at index 0
+        ac_score_by_forum[forum][reviewer] = rank_to_score[rank-1]
+
+#Load CMT conflicts
+print "loading CMT conflicts...",
+cmt_conflicts = {}
+with open('../data/reviewer-conflicts.csv') as f:
+    reader = csv.reader(f)
+    reader.next()
+    for line in reader:
+        email = line[2].strip().lower()
+        paperid = line[3].strip().lower()
+
+        if paperid in forum_by_paperid:
+            conflicted_forum = forum_by_paperid[paperid]
+
+            reviewer_profile = reviewer_profiles_by_email.get(email)
+
+            if reviewer_profile:
+                cmt_conflicts[conflicted_forum] = cmt_conflicts.get(conflicted_forum, {})
+                cmt_conflicts[conflicted_forum][reviewer_profile.id] = '-inf'
+            else:
+                print "profile not found: ", email
+
+# load openreview conflicts
+print "loading openreview conflicts...",
+openreview_conflicts = {}
+for forum, paper in papers_by_forum.iteritems():
+    forum_conflicts = {}
+    for user_id in reviewers.members:
+        reviewer_profile = reviewer_profiles_by_id[user_id]
+        author_profiles = {}
+        for authorid in paper.content['authorids']:
+            author_profiles[authorid] = author_profiles_by_email.get(authorid, None)
+
+        conflicts = openreview.matching.get_conflicts(author_profiles, reviewer_profile)
+        if conflicts:
+            forum_conflicts[reviewer_profile.id] = '-inf'
+
+    openreview_conflicts[forum] = forum_conflicts
+
+print "dumping...",
+with open('../data/score-maps.pkl', 'wb') as f:
+    pickle.dump({
+        'score_maps': {
+            'tpmsScore': scores_by_forum,
+            'acRecommendation': ac_score_by_forum
+        },
+        'constraint_maps': {
+            'cmtConflict': cmt_conflicts,
+            'openreviewConflict': openreview_conflicts
+        }
+    }, f)
+
+print "done"

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/download-score-maps.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/download-score-maps.py
@@ -71,7 +71,7 @@ with open('../data/reviewers_scores.csv') as f:
 print "loading ac ranks from file..."
 ac_rank_by_forum = {}
 max_rank = 0
-with open('../data/ac-recommendations-2018-04-07.csv') as f:
+with open('../data/ac-recommendations-2018-04-10.csv') as f:
     reader = csv.reader(f)
     for row in reader:
         ac_email = row[0].lower().strip()
@@ -109,7 +109,6 @@ print "loading CMT conflicts...",
 cmt_conflicts = {}
 with open('../data/reviewer-conflicts.csv') as f:
     reader = csv.reader(f)
-    reader.next()
     for line in reader:
         email = line[2].strip().lower()
         paperid = line[3].strip().lower()

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/import-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/import-reviewers.py
@@ -45,7 +45,7 @@ if os.path.isdir(missing_reviewer_json_dir):
 
 os.makedirs(missing_reviewer_json_dir)
 
-with open('../data/missing-reviewers-2018-04-08-1102.csv') as f:
+with open('../data/missing-reviewers-2018-04-11-1104.csv') as f:
     reader = csv.reader(f)
     for row in reader:
         missing_email = row[0].lower().strip()

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/match-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/match-reviewers.py
@@ -33,7 +33,8 @@ config_note = openreview.Note(**{
             'maxpapers': 8,
             'alternates': 5,
             'weights': {
-                'tpmsScore': 1
+                'tpmsScore': 1.0,
+                'acRecommendation': 3.0
             }
         },
         'constraints': {},

--- a/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
+++ b/venues/cv-foundation.org/ECCV/2018/Conference/python/setup-metadata-reviewers.py
@@ -19,121 +19,23 @@ args = parser.parse_args()
 client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
 print 'connecting to {0}'.format(client.baseurl)
 
+print "getting conference objects...",
 metadata_invitation = client.get_invitation('cv-foundation.org/ECCV/2018/Conference/Reviewers/-/Paper_Metadata')
-
-#Load Papers
-print "getting all submissions...",
 papers = openreview.tools.get_all_notes(client, 'cv-foundation.org/ECCV/2018/Conference/-/Submission')
-papers_by_forum = {}
-forum_by_paperId = {}
-for p in papers:
-    papers_by_forum[p.forum] = p
-    forum_by_paperId[p.content['paperId']] = p.forum
-print "done."
-
-#Load group profiles
-print "getting groups...",
 reviewers = client.get_group('cv-foundation.org/ECCV/2018/Conference/Reviewers')
-profiles_by_id = {profile.id: profile for profile in client.get_profiles(reviewers.members)}
-print "done."
 
-#Load TPMS scores
-print "loading tpms scores from file...",
-scores_by_forum = {}
-ids_by_email = {}
-with open('../data/reviewers_scores.csv') as f:
-    reader = csv.reader(f)
-    reader.next()
-    for line in reader:
-        paperId = line[0].strip()
-        email = line[1].strip().lower()
-        score = line[2].strip()
-
-        forum = forum_by_paperId.get(paperId, '')
-
-        if forum not in scores_by_forum:
-            scores_by_forum[forum] = {}
-
-        if email not in ids_by_email:
-            profiles = client.get_profiles([email])
-            if profiles:
-                userid = profiles[email].id
-            else:
-                userid = None
-            ids_by_email[email] = userid
-        else:
-            userid = ids_by_email[email]
-
-        if userid:
-            scores_by_forum[forum][userid] = float(score)
-print "done."
-
-#Load author profiles
-print "loading author profiles from file...",
-author_profiles_by_email = {}
-with open('../data/profiles.pkl', 'rb') as f:
-    author_profiles_by_email = pickle.load(f)
-print "done."
-
-#Load CMT conflicts
-print "loading CMT conflicts..."
-cmt_conflicts = {}
-profiles_by_email = {}
-with open('../data/reviewer-conflicts.csv') as f:
-    reader = csv.reader(f)
-    reader.next()
-    for line in reader:
-        email = line[2].strip().lower()
-        print email
-        paperid = line[3].strip().lower()
-        if paperid in forum_by_paperId:
-            conflicted_forum = forum_by_paperId[paperid]
-            if not email in profiles_by_email:
-                new_profiles = client.get_profiles([email])
-                if not new_profiles:
-                    profiles_by_email.update({email: None})
-                else:
-                    profiles_by_email.update(new_profiles)
-
-            userid = None
-            if email in profiles_by_email and profiles_by_email[email]:
-                userid = profiles_by_email[email].id
-
-            if userid:
-                cmt_conflicts[conflicted_forum] = cmt_conflicts.get(conflicted_forum, {})
-                cmt_conflicts[conflicted_forum][userid] = '-inf'
-print "done."
-
-# load openreview conflicts
-print "loading openreview conflicts..."
-openreview_conflicts = {}
-for forum, paper in papers_by_forum.iteritems():
-    print forum
-    forum_conflicts = {}
-    for user_id in reviewers.members:
-        profile = profiles_by_id[user_id]
-        author_profiles = {}
-        for authorid in paper.content['authorids']:
-            author_profiles[authorid] = author_profiles_by_email.get(authorid, None)
-
-        conflicts = openreview.matching.get_conflicts(author_profiles, profile)
-        if conflicts:
-            forum_conflicts[user_id] = '-inf'
-
-    openreview_conflicts[forum] = forum_conflicts
-print "done."
+print "loading score maps..."
+with open('../data/score-maps.pkl', 'rb') as f:
+    maps = pickle.load(f)
+score_maps = maps['score_maps']
+constraint_maps = maps['constraint_maps']
 
 new_metadata_notes = openreview_matcher.metadata.generate_metadata_notes(client,
     papers = papers,
     metadata_invitation = metadata_invitation,
     match_group = reviewers,
-    score_maps = {
-        'tpmsScore': scores_by_forum,
-    },
-    constraint_maps = {
-        'cmtConflict': cmt_conflicts,
-        'openreviewConflict': openreview_conflicts
-    }
+    score_maps = score_maps,
+    constraint_maps = constraint_maps
 )
 
 for m in new_metadata_notes:


### PR DESCRIPTION
redesigns the reviewer match sequence.

three scripts to download profiles make it easier to re-run the metadata and match scripts:

download-areachair-profiles.py
download-reviewer-profiles.py
download-author-profiles.py

These generate .pkl files that are later consumed by download-score-maps.py.

download-score-maps.py consumes the profile .pkl files above, processes all the data needed for the score and conflict maps, and produces a .pkl file that contains them.

setup-metadata-reviewers.py has been reduced so that it simply consumes the .pkl file created by download-score-maps.py. This has made testing much easier.

match-reviewers.py has been modified to account for acRecommendation scores.