### PR TITLE
Fix/update comment process

### DIFF
--- a/venues/auai.org/UAI/2018/process/commentProcess.js
+++ b/venues/auai.org/UAI/2018/process/commentProcess.js
@@ -62,7 +62,7 @@ function(){
         if (checkReadersMatch(/auai.org\/UAI\/2018\/Paper[0-9]+\/Reviewers/)){
           promises.push(or3client.or3request(or3client.mailUrl, reviewer_mail, 'POST', token));
         }
-        if (checkReadersMatch(/auai.org\/UAI\/2018\/Paper[0-9]+\/Area_Chairs/)){
+        else if (checkReadersMatch(/auai.org\/UAI\/2018\/Paper[0-9]+\/Area_Chairs/)){
           promises.push(or3client.or3request(or3client.mailUrl, ac_mail, 'POST', token));
         }
         if(note.readers.indexOf('auai.org/UAI/2018/Program_Chairs') > -1){

--- a/venues/auai.org/UAI/2018/python/setup-invitations.py
+++ b/venues/auai.org/UAI/2018/python/setup-invitations.py
@@ -87,7 +87,10 @@ invitation_templates = {
         'readers': ['everyone'],
         'writers': ['auai.org/UAI/2018'],
         'invitees': [mask_reviewers_group],
-        'noninvitees': [mask_submitted_group],
+        'noninvitees': [
+            mask_submitted_group,
+            mask_areachair_group
+            ],
         'signatures': ['auai.org/UAI/2018'],
         'duedate': 1524355199000, # Saturday, April 21, 2018 11:59:59 PM
         'process': os.path.join(os.path.dirname(__file__), '../process/officialReviewProcess.js'),


### PR DESCRIPTION
Some Official Comments have been made that have only the Reviewers group set as readers. the PCs would like to force these comments to be readable by the ACs as well.

To solve this, we should (1) add the AC groups to the reviewer groups, (2) update the Official_Review invitations so that the AC groups are noninvitees, and (3) update the Official_Comment process function so that the ACs don't get double emails.

To do (1), run the following:

```
papers = client.get_notes(invitation='auai.org/UAI/2018/-/Blind_Submission')
for paper in papers:
    client.add_members_to_group(client.get_group('auai.org/UAI/2018/Paper{}/Reviewers'.format(paper.number)),
                                'auai.org/UAI/2018/Paper{}/Area_Chairs'.format(paper.number))

```

To do (2) and (3), run `python setup-invitations.py Official_Review Official_Comment`. It's probably worth doing this from one of the app instances, for the sake of speed.