### PR TITLE
Fix bug with homepage webfield template

### DIFF
--- a/samples/webfield/venue_home_tabs.js
+++ b/samples/webfield/venue_home_tabs.js
@@ -261,6 +261,7 @@ function renderContent(notes, submittedNotes, userGroups) {
     if (notes.length === PAGE_SIZE) {
       Webfield.setupAutoLoading(BLIND_INVITATION, PAGE_SIZE, submissionListOptions);
     }
+    $('.tabs-container a[href="#all-submitted-papers"]').parent().show();
   } else {
     $('.tabs-container a[href="#all-submitted-papers"]').parent().hide();
   }
@@ -275,6 +276,7 @@ function renderContent(notes, submittedNotes, userGroups) {
     Webfield.ui.searchResults(assignedNotes, _.assign(
       {}, paperDisplayOptions, {container: '#my-assigned-papers'}
     ));
+    $('.tabs-container a[href="#my-assigned-papers"]').parent().show();
   } else {
     $('.tabs-container a[href="#my-assigned-papers"]').parent().hide();
   }
@@ -284,6 +286,7 @@ function renderContent(notes, submittedNotes, userGroups) {
     Webfield.ui.searchResults(commentNotes, _.assign(
       {}, commentDisplayOptions, {container: '#my-comments-reviews', emptyMessage: 'No comments or reviews to display'}
     ));
+    $('.tabs-container a[href="#my-comments-reviews"]').parent().show();
   } else {
     $('.tabs-container a[href="#my-comments-reviews"]').parent().hide();
   }

--- a/venues/ICML.cc/2018/Workshop/NAMPI/webfield/homepage.js
+++ b/venues/ICML.cc/2018/Workshop/NAMPI/webfield/homepage.js
@@ -273,6 +273,8 @@ function renderContent(notes, submittedNotes, assignedNotePairs, assignedNotes, 
         '</li>'
       ].join(''));
     }
+
+    $('.tabs-container a[href="#my-tasks"]').parent().show();
   } else {
     $('.tabs-container a[href="#my-tasks"]').parent().hide();
   }
@@ -339,7 +341,8 @@ function renderContent(notes, submittedNotes, assignedNotePairs, assignedNotes, 
         emptyMessage: 'You have no papers currently under review.'
       })
     );
-
+    $('.tabs-container a[href="#my-submitted-papers"]').parent().show();
+    $('.tabs-container a[href="#my-papers-under-review"]').parent().show();
   } else {
     $('.tabs-container a[href="#my-submitted-papers"]').parent().hide();
     $('.tabs-container a[href="#my-papers-under-review"]').parent().hide();
@@ -353,6 +356,7 @@ function renderContent(notes, submittedNotes, assignedNotePairs, assignedNotes, 
       assignedNotes,
       _.assign({}, paperDisplayOptions, {container: '#my-assigned-papers'})
     );
+    $('.tabs-container a[href="#my-comments-reviews"]').parent().show();
   } else {
     $('.tabs-container a[href="#my-assigned-papers"]').parent().hide();
   }
@@ -366,6 +370,7 @@ function renderContent(notes, submittedNotes, assignedNotePairs, assignedNotes, 
         emptyMessage: 'No comments or reviews to display'
       })
     );
+    $('.tabs-container a[href="#my-comments-reviews"]').parent().show();
   } else {
     $('.tabs-container a[href="#my-comments-reviews"]').parent().hide();
   }


### PR DESCRIPTION
Tabs that were initially hidden were not showing properly when users submitted a paper.

The only active conference that has been fixed is NAMPI 2018 Workshop. The others will have to be patched individually.