### PR TITLE
Add webpages for each conference that has multiple years and/or works…

### DIFF
--- a/venues/ICLR.cc/ICLR-landing-webfield.html
+++ b/venues/ICLR.cc/ICLR-landing-webfield.html
@@ -1,0 +1,28 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <div id='main'>
+      <div id='header'></div>
+
+      <div id='iclr', class='panel'>
+        <h3 id='iclrInfo', style="float:center">International Conference on Learning Representations</h3>
+        <div class='row'><a href='javascript:pushGroup("ICLR.cc/2018/Conference")'>ICLR 2018 Conference Track</a>
+        <div class='row'><a href='javascript:pushGroup("ICLR.cc/2018/Workshop")'>ICLR 2018 Workshop Track</a>
+        <div class='row'><a href='javascript:pushGroup("ICLR.cc/2017/conference")'>ICLR 2017 Conference Track</a>
+        <div class='row'><a href='javascript:pushGroup("ICLR.cc/2017/workshop")'>ICLR 2017 Workshop Track</a>
+        <div class='row'><a href='javascript:pushGroup("ICLR.cc/2016/workshop")'>ICLR 2016</a>
+        <div class='row'><a href='javascript:pushGroup("ICLR.cc/2014")'>ICLR 2014</a>
+        <div class='row'><a href='javascript:pushGroup("ICLR.cc/2013")'>ICLR 2013</a>
+      </div>
+
+      <div id='invitation'></div>
+      <div id='notes'></div>
+    </div>
+    <script type="text/javascript">
+    $(function() {
+
+    });
+    </script>
+ </body>
+</html>

--- a/venues/ICML.cc/ICML-landing-webfield.html
+++ b/venues/ICML.cc/ICML-landing-webfield.html
@@ -1,0 +1,31 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <div id='main'>
+      <div id='header'></div>
+
+      <div id='icml', class='panel'>
+        <h3 id='icmlInfo', style="float:center">International Conference on Machine Learning</h3>
+        <div class='row'><a href='javascript:pushGroup("ICML.cc/2018/ECA")'>ICML 2018 ECA</a>
+        <div class='row'><a href='javascript:pushGroup("ICML.cc/2018/Workshop/NAMPI")'>ICML 2018 NAMPI</a>
+        <div class='row'><a href='javascript:pushGroup("ICML.cc/2018/RML")'>ICML 2018 RML</a>
+        <div class='row'>
+          <div class='row'><a href='javascript:pushGroup("ICML.cc/2017/MLAV")'>ICML 2017 MLAV</a>
+        <div class='row'><a href='javascript:pushGroup("ICML.cc/2017/RML")'>ICML 2017 RML</a>
+        <div class='row'><a href='javascript:pushGroup("ICML.cc/2017/WHI")'>ICML 2017 WHI</a>
+        <div class='row'>
+          <div class='row'><a href='javascript:pushGroup("ICML.cc/2013/Inferning")'>ICML 2013 Inferning</a>
+        <div class='row'><a href='javascript:pushGroup("ICML.cc/2013/PeerReview")'>ICML 2013 PeerReview</a>
+      </div>
+
+      <div id='invitation'></div>
+      <div id='notes'></div>
+    </div>
+    <script type="text/javascript">
+    $(function() {
+
+    });
+    </script>
+ </body>
+</html>

--- a/venues/NIPS.cc/NIPS-landing-webfield.html
+++ b/venues/NIPS.cc/NIPS-landing-webfield.html
@@ -1,0 +1,27 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <div id='main'>
+      <div id='header'></div>
+
+      <div id='nips', class='panel'>
+        <h3 id='nipsInfo', style="float:center">Neural Information Processing Systems</h3>
+        <div class='row'><a href='javascript:pushGroup("NIPS.cc/2017/Workshop/Autodiff")'>NIPS 2017 Autodiff Workshop</a>
+        <div class='row'><a href='javascript:pushGroup("NIPS.cc/2017/Workshop/MLITS")'>NIPS 2017 MLITS Workshop</a>
+        <div class='row'>
+        <div class='row'><a href='javascript:pushGroup("NIPS.cc/2016/Deep_Learning_Symposium")'>NIPS 2016 Deep Learning Symposium</a>
+        <div class='row'><a href='javascript:pushGroup("NIPS.cc/2016/workshop/MLITS")'>NIPS 2016 MLITS Workshop</a>
+        <div class='row'><a href='javascript:pushGroup("NIPS.cc/2016/workshop/NAMPI")'>NIPS 2016 NAMPI Workshop</a>
+      </div>
+
+      <div id='invitation'></div>
+      <div id='notes'></div>
+    </div>
+    <script type="text/javascript">
+    $(function() {
+
+    });
+    </script>
+ </body>
+</html>

--- a/venues/auai.org/UAI/UAI-landing-webfield.html
+++ b/venues/auai.org/UAI/UAI-landing-webfield.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <div id='main'>
+      <div id='header'></div>
+
+      <div id='uai', class='panel'>
+        <h3 id='uaiInfo', style="float:center">Conference on Uncertainty in Artificial Intelligence</h3>
+        <div class='row'><a href='javascript:pushGroup("auai.org/UAI/2018")'>UAI 2018</a>
+        <div class='row'><a href='javascript:pushGroup("auai.org/UAI/2017")'>UAI 2017</a>
+        </div>
+      <div id='invitation'></div>
+      <div id='notes'></div>
+    </div>
+    <script type="text/javascript">
+    $(function() {
+
+    });
+    </script>
+ </body>
+</html>

--- a/venues/swsa.semanticweb.org/ISWC/ISWC-landing-webfield.html
+++ b/venues/swsa.semanticweb.org/ISWC/ISWC-landing-webfield.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <div id='main'>
+      <div id='header'></div>
+
+      <div id='iswc', class='panel'>
+        <h3 id='iswcInfo', style="float:center">Decentralizing the Semantic Web Workshop at the International Semantic Web Conference</h3>
+        <div class='row'><a href='javascript:pushGroup("swsa.semanticweb.org/ISWC/2018/DeSemWeb")'>DeSemWeb 2018</a>
+        <div class='row'><a href='javascript:pushGroup("swsa.semanticweb.org/ISWC/2017/DeSemWeb")'>DeSemWeb 2017</a>
+      </div>
+
+      <div id='invitation'></div>
+      <div id='notes'></div>
+    </div>
+    <script type="text/javascript">
+    $(function() {
+
+    });
+    </script>
+ </body>
+</html>


### PR DESCRIPTION
…hops.

Then the hosts group needs to be modified and run admin/update_homepage for each of the conference groups.
If you want host to be organized by priority, is it purely by number of submissions in the most recent year?  Or is there something else?