### PR TITLE
fix blind note creation

### DIFF
--- a/venues/ICLR.cc/2019/Conference/python/notes.py
+++ b/venues/ICLR.cc/2019/Conference/python/notes.py
@@ -52,12 +52,15 @@ def freeze_and_post(client, note):
 
 def post_blind_note(client, original_note):
     blind_note = client.post_note(create_blind_note(original_note))
+    bibtex_entry = getBibtex(client, blind_note)
     paper_group_id = iclr19.CONFERENCE_ID + "/Paper{}".format(blind_note.number)
     author_group_id = iclr19.CONFERENCE_ID + "/Paper{}/Authors".format(blind_note.number)
 
-    # Update Blind note's contents, repost the updated blind note, and freeze and post the original note
-    blind_note.content["authorids"] = [author_group_id]
-    blind_note.content["_bibtex"] = getBibtex(client, blind_note)
+    blind_note.content = {
+        "authors": ['Anonymous'],
+        "authorids": [author_group_id]
+        "_bibtex": bibtex_entry
+    }
 
     return client.post_note(blind_note)
 


### PR DESCRIPTION
@mohituniyal FYI (this was not your fault), the reason this change is important is because of a tricky detail about the interaction between note inference and blind notes.

when we run post_note on the blind note (with only authors, authorids, and bibtex in the content field), the note that gets returned is the result of inference on the blind note and the original note (so, the return value will have the authors, authorids, and bibtex fields of the blind note, and all the rest of the fields of the original note).

before this change, we then posted this inferred note again, which overwrites the blind note's reference with all the fields of the inferred note! this prevents further inference from propagating changes from the original to the blind note (because the blind note will hide all the fields from the original with its own).

this is complex, so let me know if you have questions.