### PR TITLE
Fix/bibtex and public comment

### DIFF
--- a/venues/ICLR.cc/2019/Conference/python/invitations.py
+++ b/venues/ICLR.cc/2019/Conference/python/invitations.py
@@ -219,10 +219,10 @@ public_comment_template = {
     'writers': [iclr19.CONFERENCE_ID],
     'invitees': ['~'],
     'noninvitees': [
-        iclr19.PROGRAM_CHAIRS_ID,
-        iclr19.AREA_CHAIRS_ID,
-        iclr19.REVIEWERS_ID,
-        iclr19.AUTHORS_ID
+        iclr19.PAPER_AUTHORS_TEMPLATE_STR,
+        iclr19.PAPER_REVIEWERS_TEMPLATE_STR,
+        iclr19.PAPER_AREA_CHAIRS_TEMPLATE_STR,
+        iclr19.PROGRAM_CHAIRS_ID
     ],
     'signatures': [iclr19.CONFERENCE_ID],
     'multiReply': True,

--- a/venues/ICLR.cc/2019/Conference/python/notes.py
+++ b/venues/ICLR.cc/2019/Conference/python/notes.py
@@ -20,13 +20,14 @@ import random
 def getBibtex(client, note):
     firstWord = note.content["title"].split(' ')[0].lower();
     url = client.baseurl + '/forums?id=' + note.forum
-    return '@article{\
+    return '@inproceedings{\
     \nanonymous2019' + firstWord + ',\
     \ntitle={' + note.content["title"] + '},\
     \nauthor={Anonymous},\
     \njournal={International Conference on Learning Representations},\
     \nyear={2019},\
-    \nurl={' + url + '}\
+    \nurl={' + url + '},\
+    \nnote={under review}\
     \n}'
 
 def create_blind_note(note):


### PR DESCRIPTION
bibtex change was requested by ICLR PC
Public comment change allows non-officials for a particular paper to make public comments on the paper (eg. for Paper23 - Paper23/Authors, Paper23/Reviewers, Papers23/Area_Chairs and all Program_Chairs will not be able to make Public_Comments)