### PR TITLE
fix webfield reference typo

### DIFF
--- a/venues/ICLR.cc/2019/Conference/python/bidding_stage.py
+++ b/venues/ICLR.cc/2019/Conference/python/bidding_stage.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
         reviewers.web = f.read()
         reviewers = client.post_group(reviewers)
 
-    with open('../webfield/areaChairWebfieldBiddingEnabled.js','r') as f:
+    with open('../webfield/areachairWebfieldBiddingEnabled.js','r') as f:
         area_chairs = client.get_group(iclr19.AREA_CHAIRS_ID)
         area_chairs.web = f.read()
         area_chairs = client.post_group(area_chairs)


### PR DESCRIPTION
for some reason, this causes an error in the instance, but not locally. I have no idea why. Maybe a difference in how OSX handles path names?