### PR TITLE
Updated disable_bids to empty invitees for Add_Bids invitation

### DIFF
--- a/venues/ICLR.cc/2019/Conference/python/invitations.py
+++ b/venues/ICLR.cc/2019/Conference/python/invitations.py
@@ -336,9 +336,9 @@ def enable_and_post(client, paper, template_key):
     return client.post_invitation(new_inv)
 
 def disable_bids(client):
-    disabled_invitaion = client.post_invitation(disable_invitation('Add_Bid'))
-    disabled_invitaion.invitees = []
-    return disabled_invitaion
+    disabled_invitation = client.post_invitation(disable_invitation('Add_Bid'))
+    disabled_invitation.invitees = []
+    return disabled_invitation
 
 if __name__ == '__main__':
     ## Argument handling

--- a/venues/ICLR.cc/2019/Conference/python/invitations.py
+++ b/venues/ICLR.cc/2019/Conference/python/invitations.py
@@ -336,7 +336,9 @@ def enable_and_post(client, paper, template_key):
     return client.post_invitation(new_inv)
 
 def disable_bids(client):
-    return client.post_invitation(disable_invitation('Add_Bid'))
+    disabled_invitaion = client.post_invitation(disable_invitation('Add_Bid'))
+    disabled_invitaion.invitees = []
+    return disabled_invitaion
 
 if __name__ == '__main__':
     ## Argument handling


### PR DESCRIPTION
PR contains changes to empty the invitees field of the Add_Bid invitation.

Note: The way add_bid is getting enabled or disabled right now is the same enable/disable function runs for each blind submission, which is not at all required. This will be fixed in another PR.
