### PR TITLE
script to add/remove reviewers for a given paper

### DIFF
--- a/venues/ICLR.cc/2019/Conference/python/programchairs/assign-reviewer.py
+++ b/venues/ICLR.cc/2019/Conference/python/programchairs/assign-reviewer.py
@@ -66,17 +66,13 @@ if __name__ == "__main__":
         if '@' in reviewer_to_remove:
             reviewer_to_remove = reviewer_to_remove.lower()
         
-        (user,changed_groups_rem) = openreview.tools.remove_assignment(client, paper_number, conference, reviewer_to_remove,
-                                            parent_group_params = {},
-                                            parent_label = 'Reviewers',
-                                            individual_label = 'AnonReviewer')
+        (user,changed_groups_rem) = openreview.tools.remove_assignment(client, paper_number, conference, reviewer_to_remove)
         reviewer_to_remove = user
         anonReviewerGroup = ""
         
-        try:
-            anonReviewerGroup = [grp for grp in changed_groups_rem if anonReviewerRegex.match(str(grp))][0]
-        except IndexError as e:
-            pass
+        matchResult = next(filter(anonReviewerRegex.match,changed_groups_rem),None)
+        if (matchResult):
+            anonReviewerGroup = matchResult
         
         client.remove_members_from_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
         changed_groups_rem.append(unsubmittedGroupId)
@@ -89,13 +85,11 @@ if __name__ == "__main__":
             reviewer_to_add = reviewer_to_add.lower()
         
         (user,changed_groups_add) = openreview.tools.add_assignment(client, paper_number, conference, reviewer_to_add,
-                            parent_group_params = {}, individual_group_params = {'readers': [
+                            individual_group_params = {'readers': [
                             'ICLR.cc/2019/Conference',
                             'ICLR.cc/2019/Conference/Program_Chairs',
                             'ICLR.cc/2019/Conference/Paper{}/Area_Chairs'.format(paper_number)
-                            ]}, 
-                            parent_label = 'Reviewers', 
-                            individual_label = 'AnonReviewer')
+                            ]})
         reviewer_to_add = user
         anonReviewerGroup = ""
         

--- a/venues/ICLR.cc/2019/Conference/python/programchairs/assign-reviewer.py
+++ b/venues/ICLR.cc/2019/Conference/python/programchairs/assign-reviewer.py
@@ -1,0 +1,104 @@
+## Import statements
+import argparse
+import sys
+import csv
+import openreview
+import re
+
+'''
+Requirements:
+
+openreview-py
+
+Usage:
+
+Use the --paper (-p) flag to specify the paper number.
+Use the --add (-a) flag to specify a username or email address to assign.
+Use the --remove (-r) flag to specify a username or email address to remove.
+
+The script processes removals before additions, and assigns the user to the
+lowest AnonReviewer# group that is empty.
+
+For example, after running the following:
+
+python assign-reviewer.py --paper 123 --remove ~Oriol_Vinyals1 --add ~MarcAurelio_Ranzato1
+
+
+Paper123/Reviewers = {
+    AnonReviewer1: ~Tara_Sainath1
+    AnonReviewer2: ~Oriol_Vinyals1
+    AnonReviewer3: ~Iain_Murray1
+}
+
+becomes
+
+Paper123/Reviewers = {
+    AnonReviewer1: ~Tara_Sainath1
+    AnonReviewer2: ~MarcAurelio_Ranzato1
+    AnonReviewer3: ~Iain_Murray1
+}
+'''
+
+if __name__ == "__main__":
+    ## Argument handling
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p','--paper', required=True)
+    parser.add_argument('-a','--add')
+    parser.add_argument('-r','--remove')
+    parser.add_argument('--baseurl', help="base url")
+    parser.add_argument('--username')
+    parser.add_argument('--password')
+
+    args = parser.parse_args()
+
+    client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+
+    paper_number = args.paper
+    reviewer_to_remove = args.remove
+    reviewer_to_add = args.add
+
+    if reviewer_to_remove and '@' in reviewer_to_remove:
+        reviewer_to_remove = reviewer_to_remove.lower()
+
+    if reviewer_to_add and '@' in reviewer_to_add:
+        reviewer_to_add = reviewer_to_add.lower()
+    
+    (user,changed_groups) = openreview.tools.assign(client, paper_number, 'ICLR.cc/2019/Conference',
+        individual_group_params = {'readers': [
+            'ICLR.cc/2019/Conference',
+            'ICLR.cc/2019/Conference/Program_Chairs',
+            'ICLR.cc/2019/Conference/Paper{}/Area_Chairs'.format(paper_number)
+            ]},
+        reviewer_to_add = reviewer_to_add,
+        reviewer_to_remove = reviewer_to_remove,
+        parent_label = 'Reviewers',
+        individual_label = 'AnonReviewer')
+
+    userInUnsubmitted = 0
+    paperUrl = "ICLR.cc/2019/Conference/Paper{}".format(paper_number)
+    unsubmittedGroupId = paperUrl + "/Reviewers/Unsubmitted"
+    anonReviewerRegex = re.compile(paperUrl+"/AnonReviewer.*")
+    anonReviewerGroup = ""
+
+    try:
+        anonReviewerGroup = [grp for grp in changed_groups if anonReviewerRegex.match(str(grp))][0]
+    except Exception as e:
+        pass
+
+    if anonReviewerGroup and (anonReviewerGroup in client.get_group(id=unsubmittedGroupId).members):
+        userInUnsubmitted = 1
+    
+    if reviewer_to_remove:
+        if userInUnsubmitted and anonReviewerGroup:
+            client.remove_members_from_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
+            changed_groups.append(unsubmittedGroupId)
+        if not changed_groups:
+            print("{:40s} is already not a part of any groups for Paper --> {}".format(user, paper_number))
+        for grp in changed_groups:
+            print("{:40s} removed from --> {}".format(user, grp))
+    elif reviewer_to_add:
+        if not userInUnsubmitted and anonReviewerGroup:
+            client.add_members_to_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
+            changed_groups.append(unsubmittedGroupId)
+        for grp in changed_groups:
+            print("{:40s} added to --> {}".format(user, grp))

--- a/venues/ICLR.cc/2019/Conference/python/programchairs/assign-reviewer.py
+++ b/venues/ICLR.cc/2019/Conference/python/programchairs/assign-reviewer.py
@@ -68,13 +68,10 @@ if __name__ == "__main__":
         
         (user,changed_groups_rem) = openreview.tools.remove_assignment(client, paper_number, conference, reviewer_to_remove)
         reviewer_to_remove = user
-        anonReviewerGroup = ""
         
-        matchResult = next(filter(anonReviewerRegex.match,changed_groups_rem),None)
-        if (matchResult):
-            anonReviewerGroup = matchResult
-        
-        client.remove_members_from_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
+        anonReviewerGroup = next(filter(anonReviewerRegex.match,changed_groups_rem), None)
+        if anonReviewerGroup:
+            client.remove_members_from_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
         changed_groups_rem.append(unsubmittedGroupId)
         
         for grp in changed_groups_rem:
@@ -91,14 +88,10 @@ if __name__ == "__main__":
                             'ICLR.cc/2019/Conference/Paper{}/Area_Chairs'.format(paper_number)
                             ]})
         reviewer_to_add = user
-        anonReviewerGroup = ""
         
-        try:
-            anonReviewerGroup = [grp for grp in changed_groups_add if anonReviewerRegex.match(str(grp))][0]
-        except IndexError as e:
-            pass
-        
-        client.add_members_to_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
+        anonReviewerGroup = next(filter(anonReviewerRegex.match,changed_groups_add), "")
+        if anonReviewerGroup:
+            client.add_members_to_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
         changed_groups_add.append(unsubmittedGroupId)
         
         for grp in changed_groups_add:

--- a/venues/ICLR.cc/2019/Conference/python/programchairs/assign-reviewer.py
+++ b/venues/ICLR.cc/2019/Conference/python/programchairs/assign-reviewer.py
@@ -58,6 +58,9 @@ if __name__ == "__main__":
     reviewer_to_add = args.add
 
     conference = 'ICLR.cc/2019/Conference'
+    paperUrl = "ICLR.cc/2019/Conference/Paper{}".format(paper_number)
+    unsubmittedGroupId = paperUrl + "/Reviewers/Unsubmitted"
+    anonReviewerRegex = re.compile(paperUrl+"/AnonReviewer.*")
 
     if reviewer_to_remove :
         if '@' in reviewer_to_remove:
@@ -68,6 +71,18 @@ if __name__ == "__main__":
                                             parent_label = 'Reviewers',
                                             individual_label = 'AnonReviewer')
         reviewer_to_remove = user
+        anonReviewerGroup = ""
+        
+        try:
+            anonReviewerGroup = [grp for grp in changed_groups_rem if anonReviewerRegex.match(str(grp))][0]
+        except IndexError as e:
+            pass
+        
+        client.remove_members_from_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
+        changed_groups_rem.append(unsubmittedGroupId)
+        
+        for grp in changed_groups_rem:
+            print("{:40s} removed from --> {}".format(reviewer_to_remove, grp))
 
     if reviewer_to_add :
         if '@' in reviewer_to_add:
@@ -82,27 +97,6 @@ if __name__ == "__main__":
                             parent_label = 'Reviewers', 
                             individual_label = 'AnonReviewer')
         reviewer_to_add = user
-    
-    
-    paperUrl = "ICLR.cc/2019/Conference/Paper{}".format(paper_number)
-    unsubmittedGroupId = paperUrl + "/Reviewers/Unsubmitted"
-    anonReviewerRegex = re.compile(paperUrl+"/AnonReviewer.*")
-
-    if reviewer_to_remove:
-        anonReviewerGroup = ""
-        
-        try:
-            anonReviewerGroup = [grp for grp in changed_groups_rem if anonReviewerRegex.match(str(grp))][0]
-        except IndexError as e:
-            pass
-        
-        client.remove_members_from_group(client.get_group(unsubmittedGroupId),anonReviewerGroup)
-        changed_groups_rem.append(unsubmittedGroupId)
-        
-        for grp in changed_groups_rem:
-            print("{:40s} removed from --> {}".format(reviewer_to_remove, grp))
-    
-    if reviewer_to_add:
         anonReviewerGroup = ""
         
         try:


### PR DESCRIPTION
This script call Client.assign to add/remove reviewers to/from PaperYYY/Reviewers and PaperYYY/AnonReviewerZ groups. Additionally, it adds/removes the reviewers from PaperYYY/Reviewers/Unsubmitted. This makes the following 2 assumptions: 
1. While adding a new reviewer, this reviewer does not already have reviews posted for the paper YYY.
2. While removing a reviewer, this reviewer has not posted any reviews for paper YYY and hence still is in the group PaperYYY/Reviewers/Unsubmitted.