### PR TITLE
Disable confirmation message for single reminder emails 

### DIFF
--- a/venues/ICLR.cc/2019/Conference/webfield/areachairWebfield.js
+++ b/venues/ICLR.cc/2019/Conference/webfield/areachairWebfield.js
@@ -622,8 +622,10 @@ var registerEventHandlers = function() {
       };
 
       $('#message-reviewers-modal').modal('hide');
-      promptMessage('Your reminder email has been sent to ' + view.prettyId(userId));
+      // promptMessage('Your reminder email has been sent to ' + view.prettyId(userId));
       postReviewerEmails(postData);
+      $(this).parent().append('<span>(Last sent: ' + (new Date()).toLocaleDateString('en-GB') + '</span>');
+
       return false;
     };
 


### PR DESCRIPTION
And immediately show last sent date.

Any help testing this would be appreciated since I don't have any paper assignment groups set up. 