### PR TITLE
Iclr19/comment and review process

### DIFF
--- a/venues/ICLR.cc/2019/Conference/process/commentProcess.js
+++ b/venues/ICLR.cc/2019/Conference/process/commentProcess.js
@@ -74,6 +74,7 @@ function(){
       // Sends a message to Program Chairs only if the message is readable by only PCs,
       // or only ACs and PCs. This will prevent the PCs from being constantly spammed.
       if(note.readers.includes(PROGRAM_CHAIRS) &&
+        !note.readers.includes(PAPER_AREACHAIRS) &&
         !note.readers.includes('everyone') &&
         !note.readers.includes(PAPER_REVIEWERS)
         ){

--- a/venues/ICLR.cc/2019/Conference/process/officialReviewProcess.js
+++ b/venues/ICLR.cc/2019/Conference/process/officialReviewProcess.js
@@ -4,6 +4,7 @@ function(){
     var or3client = lib.or3client;
 
     var CONFERENCE_ID = 'ICLR.cc/2019/Conference';
+    var SHORT_PHRASE = "ICLR 2019";
     var PAPER_REVIEWERS;
     var PAPER_AREACHAIRS;
 
@@ -15,17 +16,25 @@ function(){
 
       PAPER_REVIEWERS = CONFERENCE_ID + '/Paper' + note_number + '/Reviewers';
       PAPER_AREACHAIRS = CONFERENCE_ID + '/Paper' + note_number + '/Area_Chairs';
+      PAPER_AUTHORS = CONFERENCE_ID + '/Paper' + note_number + '/Authors'
       console.log(PAPER_REVIEWERS);
       console.log(PAPER_AREACHAIRS);
+      console.log(PAPER_AUTHORS)
       console.log(note_number);
       var areachair_mail = {
         "groups": [PAPER_AREACHAIRS],
-        "subject": "Review posted to your assigned paper: \"" + forum.content.title + "\"",
-        "message": "A submission to " + CONFERENCE_ID + ", for which you are an official area chair, has received an official review. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.review + "\n\nTo view the review, click here: " + baseUrl + "/forum?id=" + note.forum
+        "subject": "[" + SHORT_PHRASE + "] Review posted to your assigned paper: \"" + forum.content.title + "\"",
+        "message": "A submission to " + SHORT_PHRASE + ", for which you are an official area chair, has received an official review. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.review + "\n\nTo view the review, click here: " + baseUrl + "/forum?id=" + note.forum
+      };
+      var author_mail = {
+        "groups": [PAPER_AUTHORS],
+        "subject": "[" + SHORT_PHRASE + "] Review posted to your submission: \"" + forum.content.title + "\"",
+        "message": "Your submission to " + SHORT_PHRASE + " has received an official review. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.review + "\n\nTo view the review, click here: " + baseUrl + "/forum?id=" + note.forum
       };
       var areachairMailP = or3client.or3request( or3client.mailUrl, areachair_mail, 'POST', token );
+      var authorMailP = or3client.or3request( or3client.mailUrl, author_mail, 'POST', token );
 
-      return areachairMailP;
+      return areachairMailP, authorMailP;
     })
     .then(result => {
       console.log('attempting to add to group ' + PAPER_REVIEWERS + '/Submitted');


### PR DESCRIPTION
This PR is based on the following set of requests from ICLR PCs. I have covered the first and the third requirement. I am planning to do the second requirement in another PR.

1. Would it be possible to set up emails to *ACs* (but not PCs) each time the authors post AC-only comments on their papers? 
2. And, similarly, generate emails to reviewers when authors post replies to reviewers? I'm also not sure whether the system generates an email to the reviewer when the author replies to a review, but it probably should (esp. given the somewhat shorter rebuttal period, this would be a good mechanism to get reviewers to be responsive).
3. Less critical but also helpful would be if the system can generate emails to authors when reviews are posted, which might be helpful for those late reviews.