### PR TITLE
Set replyCount to false so that it does not appear on author console

### DIFF
--- a/venues/AKBC.ws/2019/Conference/webfield/authorWebfield.js
+++ b/venues/AKBC.ws/2019/Conference/webfield/authorWebfield.js
@@ -14,7 +14,7 @@ var PAGE_SIZE = 50;
 
 var paperDisplayOptions = {
   pdfLink: true,
-  replyCount: true,
+  replyCount: false,
   showContents: true
 };
 

--- a/venues/ICLR.cc/2019/Conference/webfield/authorWebfield.js
+++ b/venues/ICLR.cc/2019/Conference/webfield/authorWebfield.js
@@ -14,7 +14,7 @@ var PAGE_SIZE = 50;
 
 var paperDisplayOptions = {
   pdfLink: true,
-  replyCount: true,
+  replyCount: false,
   showContents: true
 };
 


### PR DESCRIPTION
Authors were seeing "reply: 0" on Your submissions tab in Author Console. Two options to fix that were:
1. Turn off showing the reply count on Author Console.
2. Request for replyCount in details while fetching notes for this author. 
This is how we are getting notes right now:
```
var SUBMISSION_ID = CONFERENCE_ID + '/-/Submission';
authorNotesP = Webfield.get('/notes', {
      'content.authorids': user.profile.id,
      invitation: SUBMISSION_ID
    })
```
Even if I implement the second option, the replyCount would stay 0 as the replies are made to the Blind note. So, instead of showing the author their blind notes, I decided to go with the first option.