### PR TITLE
Change all webfields to use Webfield.ui.done and not call .click 

### DIFF
--- a/venues/AKBC.ws/2019/Conference/webfield/authorWebfield.js
+++ b/venues/AKBC.ws/2019/Conference/webfield/authorWebfield.js
@@ -18,8 +18,6 @@ var paperDisplayOptions = {
   showContents: true
 };
 
-var initialPageLoad = true;
-
 HEADER_TEXT = 'AKBC 2019 Author Console';
 
 INSTRUCTIONS = '\
@@ -79,7 +77,7 @@ function load() {
       replyto: true,
       details:'replytoNote,repliedNotes'
     }).then(function(result) {return result.invitations;});
-    
+
     tagInvitationsP = Webfield.get('/invitations', {
       invitation: CONFERENCE_ID + '/-/.*',
       invitee: true,

--- a/venues/AKBC.ws/2019/Conference/webfield/homepage.js
+++ b/venues/AKBC.ws/2019/Conference/webfield/homepage.js
@@ -64,7 +64,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
@@ -131,7 +130,7 @@ function renderSubmissionButton() {
 
           load().then(renderContent).then(function() {
             // Select the first available tab
-            $('.tabs-container ul.nav-tabs > li > a:visible').eq(0).click();
+            $('.tabs-container a[href="#your-consoles"]').click();
           });
         }
       });
@@ -157,10 +156,8 @@ function renderConferenceTabs() {
 }
 
 function renderContent(userGroups, activityNotes, authorNotes) {
-  
   // Your Consoles tab
   if (userGroups.length || authorNotes.length) {
-
     var $container = $('#your-consoles').empty();
     $container.append('<ul class="list-unstyled submissions-list">');
 
@@ -219,8 +216,6 @@ function renderContent(userGroups, activityNotes, authorNotes) {
 
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  Webfield.ui.done();
 }
 
 // Go!

--- a/venues/AKBC.ws/2019/Conference/webfield/homepagePostSubmission.js
+++ b/venues/AKBC.ws/2019/Conference/webfield/homepagePostSubmission.js
@@ -67,7 +67,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
@@ -289,8 +288,6 @@ function renderContent(notes, withdrawnNotes, userGroups, activityNotes, authorN
 
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  Webfield.ui.done();
 }
 
 // Go!

--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_decision_tabs.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_decision_tabs.js
@@ -11,8 +11,6 @@ var INVITATION = CONFERENCE + '/-/Submission';
 var BLIND_INVITATION = CONFERENCE + '/-/Blind_Submission';
 var WITHDRAWN_INVITATION = CONFERENCE + '/-/Withdrawn_Submission';
 
-var initialPageLoad = true;
-
 // Main is the entry point to the webfield code and runs everything
 function main() {
   Webfield.ui.setup('#group-container', CONFERENCE);  // required
@@ -21,7 +19,7 @@ function main() {
 
   renderConferenceTabs();
 
-  load().then(renderContent);
+  load().then(renderContent).done(Webfield.ui.done);
 }
 
 // Load makes all the API calls needed to get the data to render the page
@@ -139,16 +137,8 @@ function renderContent(notes, withdrawnNotes, decisionsNotes) {
     _.assign({}, paperDisplayOptions, {showTags: false, container: '#withdrawn-papers'})
   );
 
-
-
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  // Show first available tab
-  if (initialPageLoad) {
-    $('.tabs-container ul.nav-tabs li a:visible').eq(0).click();
-    initialPageLoad = false;
-  }
 }
 
 // Go!

--- a/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
+++ b/venues/ICLR.cc/2018/Conference/webfield/conferenceWebfield_tabs.js
@@ -38,7 +38,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
@@ -50,7 +49,7 @@ function main() {
 
   renderConferenceTabs();
 
-  load().then(renderContent);
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
 // Load makes all the API calls needed to get the data to render the page
@@ -366,12 +365,6 @@ function renderContent(notes, submittedNotes, assignedNotePairs, assignedNotes, 
 
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  // Show first available tab
-  if (initialPageLoad) {
-    $('.tabs-container ul.nav-tabs li a:visible').eq(0).click();
-    initialPageLoad = false;
-  }
 }
 
 // Helper functions

--- a/venues/ICLR.cc/2018/Workshop/webfield/workshopWebfield_decision_tabs.js
+++ b/venues/ICLR.cc/2018/Workshop/webfield/workshopWebfield_decision_tabs.js
@@ -10,8 +10,6 @@ var CONFERENCE = 'ICLR.cc/2018/Workshop';
 var INVITATION = CONFERENCE + '/-/Submission';
 var WITHDRAWN_INVITATION = CONFERENCE + '/-/Withdraw_Submission';
 
-var initialPageLoad = true;
-
 // Main is the entry point to the webfield code and runs everything
 function main() {
   Webfield.ui.setup('#group-container', CONFERENCE);  // required
@@ -20,7 +18,7 @@ function main() {
 
   renderConferenceTabs();
 
-  load().then(renderContent);
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
 // Load makes all the API calls needed to get the data to render the page
@@ -47,7 +45,7 @@ function renderConferenceHeader() {
     location: 'Vancouver Convention Center, Vancouver, BC, Canada',
     date: 'April 30 - May 3, 2018',
     website: 'http://www.iclr.cc'
-    })
+  });
   Webfield.ui.spinner('#notes');
 }
 
@@ -114,12 +112,6 @@ function renderContent(notes, withdrawnNotes, decisionsNotes) {
 
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  // Show first available tab
-  if (initialPageLoad) {
-    $('.tabs-container ul.nav-tabs li a:visible').eq(0).click();
-    initialPageLoad = false;
-  }
 }
 
 // Go!

--- a/venues/ICLR.cc/2018/Workshop/webfield/workshopWebfield_tabs.js
+++ b/venues/ICLR.cc/2018/Workshop/webfield/workshopWebfield_tabs.js
@@ -30,7 +30,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
@@ -43,7 +42,7 @@ function main() {
 
   renderConferenceTabs();
 
-  load().then(renderContent);
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
 // Load makes all the API calls needed to get the data to render the page
@@ -353,12 +352,6 @@ function renderContent(notes, submittedNotes, assignedNotePairs, assignedNotes, 
 
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  // Show first available tab
-  if (initialPageLoad) {
-    $('.tabs-container ul.nav-tabs li a:visible').eq(0).click();
-    initialPageLoad = false;
-  }
 }
 
 // Helper functions

--- a/venues/ICLR.cc/2019/Conference/webfield/authorWebfield.js
+++ b/venues/ICLR.cc/2019/Conference/webfield/authorWebfield.js
@@ -18,8 +18,6 @@ var paperDisplayOptions = {
   showContents: true
 };
 
-var initialPageLoad = true;
-
 HEADER_TEXT = 'ICLR 2019 Author Console';
 
 INSTRUCTIONS = '\

--- a/venues/ICLR.cc/2019/Conference/webfield/homepage.js
+++ b/venues/ICLR.cc/2019/Conference/webfield/homepage.js
@@ -63,7 +63,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {

--- a/venues/ICLR.cc/2019/Conference/webfield/homepagePostSubmission.js
+++ b/venues/ICLR.cc/2019/Conference/webfield/homepagePostSubmission.js
@@ -65,7 +65,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {

--- a/venues/ICML.cc/2018/Workshop/NAMPI/webfield/homepage.js
+++ b/venues/ICML.cc/2018/Workshop/NAMPI/webfield/homepage.js
@@ -63,7 +63,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
@@ -75,7 +74,7 @@ function main() {
 
   renderConferenceTabs();
 
-  load().then(renderContent);
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
 // Load makes all the API calls needed to get the data to render the page
@@ -375,12 +374,6 @@ function renderContent(notes, submittedNotes, assignedNotePairs, assignedNotes, 
 
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  // Show first available tab
-  if (initialPageLoad) {
-    $('.tabs-container ul.nav-tabs li a:visible').eq(0).click();
-    initialPageLoad = false;
-  }
 }
 
 // Helper functions

--- a/venues/ICML.cc/2019/Conference/webfield/homepage.js
+++ b/venues/ICML.cc/2019/Conference/webfield/homepage.js
@@ -77,7 +77,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {

--- a/venues/MIDL.io/2019/Conference/webfield/authorWebfield.js
+++ b/venues/MIDL.io/2019/Conference/webfield/authorWebfield.js
@@ -15,8 +15,6 @@ var paperDisplayOptions = {
   showContents: true
 };
 
-var initialPageLoad = true;
-
 HEADER_TEXT = 'MIDL 2019 Author Console';
 
 INSTRUCTIONS = ' ';

--- a/venues/NIPS.cc/2018/Workshop/CDNNRIA/webfield/conferenceWebfield.js
+++ b/venues/NIPS.cc/2018/Workshop/CDNNRIA/webfield/conferenceWebfield.js
@@ -17,9 +17,9 @@ var LOCATION = 'Montreal, Canada';
 var SUBMISSION_INVITATION = 'NIPS.cc/2018/Workshop/CDNNRIA/-/Submission';
 var BLIND_INVITATION = 'NIPS.cc/2018/Workshop/CDNNRIA/-/Blind_Submission';
 var ACCEPTED_INVITATION = 'NIPS.cc/2018/Workshop/CDNNRIA/-/Paper.*/Decision';
-var INSTRUCTIONS = 'This workshop aims to bring together researchers, educators,\
- practitioners who are interested in techniques as well as applications of making \
- compact and efficient neural network representations. <br/>\
+var INSTRUCTIONS = 'This workshop aims to bring together researchers, educators, \
+practitioners who are interested in techniques as well as applications of making \
+compact and efficient neural network representations. <br/>\
 One main theme of the workshop discussion is to build up consensus in this rapidly \
 developed field, and in particular, to establish close connection between \
 researchers in machine learning community and engineers in industry. \
@@ -45,7 +45,6 @@ https://nips.cc/Conferences/2018/Schedule?showEvent=10941</a><br/>';
 
 var BUFFER = 1000 * 60 * 30;  // 30 minutes
 var PAGE_SIZE = 50;
-var initialPageLoad = true;
 
 var paperDisplayOptions = {
   pdfLink: true,
@@ -60,7 +59,7 @@ function main() {
   renderConferenceHeader();
   renderWorkshopTabs();
 
-  load().then(renderContent);
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
 // RenderConferenceHeader renders the static info at the top of the page. Since that content
@@ -142,12 +141,6 @@ function renderContent(notes, accepted) {
 
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  // Show first available tab
-  if (initialPageLoad) {
-    $('.tabs-container ul.nav-tabs li a:visible').eq(0).click();
-    initialPageLoad = false;
-  }
 }
 
 // Go!

--- a/venues/OpenReview.net/Archive/archiveWebfield.js
+++ b/venues/OpenReview.net/Archive/archiveWebfield.js
@@ -76,9 +76,7 @@ function main() {
   renderSubmissionButton(DIRECT_UPLOAD_ID);
   renderConferenceTabs();
 
-  load().then(renderContent).then(function() {
-    $('.tabs-container a[href="#imported-papers"]').click();
-  });
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
 // Load makes all the API calls needed to get the data to render the page

--- a/venues/auai.org/UAI/2018/webfield/homepage.js
+++ b/venues/auai.org/UAI/2018/webfield/homepage.js
@@ -12,7 +12,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 //<CONFERENCE>
 //<AREA_CHAIRS>
@@ -41,7 +40,7 @@ function main() {
   renderConferenceHeader();
   renderSubmissionButton();
   renderConferenceTabs();
-  load().then(renderContent);
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
 // Load makes all the API calls needed to get the data to render the page
@@ -337,12 +336,6 @@ function renderContent(notes, submittedNotes, assignedNotePairs, assignedNotes, 
 
   $('#notes .spinner-container').remove();
   $('.tabs-container').show();
-
-  // Show first available tab
-  if (initialPageLoad) {
-    $('.tabs-container ul.nav-tabs li a:visible').eq(0).click();
-    initialPageLoad = false;
-  }
 }
 
 // Helper functions

--- a/venues/iscb.org/ISMB/2019/webfield/homepage.js
+++ b/venues/iscb.org/ISMB/2019/webfield/homepage.js
@@ -12,7 +12,6 @@ var commentDisplayOptions = {
   showContents: false,
   showParent: true
 };
-var initialPageLoad = true;
 
 //<CONFERENCE>
 //<AREA_CHAIRS>


### PR DESCRIPTION
Not a critical change, so not all these webfields need to be updated on live. I wanted to change all in case any code was re-used in a future conference. The issue with calling .click on the tab is that doing so will update the browser history and overwrite and existing url hash.