### PR TITLE
fix for paper specific area chair issue

### DIFF
--- a/venues/AKBC.ws/2019/Conference/python/assign.py
+++ b/venues/AKBC.ws/2019/Conference/python/assign.py
@@ -45,12 +45,13 @@ if __name__ == '__main__':
         if assignment_note.content['label'] == args.label:
             paper_number = get_number_from_details(assignment_note.details)
             assignment_entries = assignment_note.content['assignedGroups']
+            paper_specific_area_chairs = conference_config.CONFERENCE_ID + '/Paper{}'.format(paper_number) + "/Area_Chairs"
 
             if args.type == 'reviewers':
                 parent_label = 'Reviewers'
                 individual_label = 'AnonReviewer'
                 individual_group_params = {'readers': [
-                    conference_config.AREA_CHAIRS_ID,
+                    paper_specific_area_chairs,
                     conference_config.PROGRAM_CHAIRS_ID
                 ]}
 

--- a/venues/ICLR.cc/2019/Conference/python/assign.py
+++ b/venues/ICLR.cc/2019/Conference/python/assign.py
@@ -44,7 +44,6 @@ if __name__ == '__main__':
     anonreviewerids_by_forum = defaultdict(list)
 
     for assignment_note in assignment_notes:
-        print(assignment_note.content['label'])
         if assignment_note.content['label'] == args.label:
             paper_number = get_number_from_details(assignment_note.details)
             assignment_entries = assignment_note.content['assignedGroups']

--- a/venues/ICLR.cc/2019/Conference/python/assign.py
+++ b/venues/ICLR.cc/2019/Conference/python/assign.py
@@ -44,15 +44,17 @@ if __name__ == '__main__':
     anonreviewerids_by_forum = defaultdict(list)
 
     for assignment_note in assignment_notes:
+        print(assignment_note.content['label'])
         if assignment_note.content['label'] == args.label:
             paper_number = get_number_from_details(assignment_note.details)
             assignment_entries = assignment_note.content['assignedGroups']
-
+            paper_specific_area_chairs = iclr19.CONFERENCE_ID + '/Paper{}'.format(paper_number) + "/Area_Chairs"
+            
             if args.type == 'reviewers':
                 parent_label = 'Reviewers'
                 individual_label = 'AnonReviewer'
                 individual_group_params = {'readers': [
-                    iclr19.AREA_CHAIRS_ID,
+                    paper_specific_area_chairs,
                     iclr19.PROGRAM_CHAIRS_ID
                 ]}
 


### PR DESCRIPTION
Fixes the issue where any area chair is able to see the identities of all the anonymous reviewer, regardless of whether these reviewers are assigned to one of the AC's papers.