### PR TITLE
Paper reviewers should initially be None

### DIFF
--- a/venues/ACM.org/SIGIR/Badging/process/submissionProcess.js
+++ b/venues/ACM.org/SIGIR/Badging/process/submissionProcess.js
@@ -125,7 +125,7 @@ function() {
     duedate: 1575732251000,
     signatures: [CONF],
     writers: [CONF, Conf_Chairs],
-    invitees: [Conf_Reviewers],
+    invitees: [],
     readers: ['everyone'],
     reply: {
       forum: note.id,


### PR DESCRIPTION
We were adding the whole reviewer's pool as reviewers to each new submission to ACM. This fix initialized the invitees field to null instead of initializing it to the conference reviewer's pool.