### PR TITLE
Remove all uses of HTML comments from webfield code

### DIFF
--- a/venues/ICLR.cc/2019/Conference/webfield/authorWebfield.js
+++ b/venues/ICLR.cc/2019/Conference/webfield/authorWebfield.js
@@ -27,40 +27,39 @@ INSTRUCTIONS = '\
     No! PDFs are not automatically anonymized. Authors should submit PDFs without author identities.\
   </p>';
 
-var SCHEDULE_HTML = '<h4>Submission Period</h4>\
-  <p>\
-    <!--<em><strong>Submission deadline: Thursday, September 27</strong></em>:-->\
-    <ul>\
-      <li>Authors can revise their paper as many times as needed up to the paper submission deadline.</li>\
-      <li>Please ensure that the email addresses of the corresponding author are up-to-date in his or her profile.</li>\
-    </ul>\
-  </p>\
-  <!--<p>\
-    <em><strong>Please do the following by Monday, October 8</strong></em>:\
-    <ul>\
-      <li>Update your profile to include your most up-to-date information, including work history and relations, to ensure proper conflict-of-interest detection during the paper matching process.</li> \
-      <li>Complete the ICLR registration form (found in your Tasks view).</li>\
-    </ul>\
-  </p>-->\
-  <br>\
-  <h4>Reviewing Period</h4>\
-  <p>\
-    <!--<em><strong>Reviews can be expected by Wednesday, October 17</strong></em>:-->\
-    <ul>\
-      <li>During the review period, authors will not be allowed to revise their paper. </li>\
-      <li>Reviews and all discussion take place on the Anonymous Versions of your submitted papers.</li>\
-    </ul>\
-  </p>\
-  <br>\
-  <h4>Rebuttal Period</h4>\
-  <p>\
-    <!--<em><strong>Rebuttal period ends on Friday, October 26</strong></em>:-->\
-    <ul>\
-      <li>Authors may revise their paper, but revision history will be available to reviewers.</li>\
-      <li>Area chairs and reviewers reserve the right to ignore changes which are significant from the original scope of the paper.</li>\
-    </ul>\
-  </p>\
-  <br>'
+var SCHEDULE_HTML = '<h4>Submission Period</h4>' +
+  '<p>' +
+    // '<em><strong>Submission deadline: Thursday, September 27</strong></em>:' +
+    '<ul>' +
+      '<li>Authors can revise their paper as many times as needed up to the paper submission deadline.</li>' +
+      '<li>Please ensure that the email addresses of the corresponding author are up-to-date in his or her profile.</li>' +
+    '</ul>' +
+  '</p>' +
+  // '<p>' +
+  //   '<em><strong>Please do the following by Monday, October 8</strong></em>:' +
+  //   '<ul>' +
+  //     '<li>Update your profile to include your most up-to-date information, including work history and relations, to ensure proper conflict-of-interest detection during the paper matching process.</li> ' +
+  //     '<li>Complete the ICLR registration form (found in your Tasks view).</li>' +
+  //   '</ul>' +
+  // '</p>' +
+  '<br>' +
+  '<h4>Reviewing Period</h4>' +
+  '<p>' +
+    // '<em><strong>Reviews can be expected by Wednesday, October 17</strong></em>:' +
+    '<ul>' +
+      '<li>During the review period, authors will not be allowed to revise their paper. </li>' +
+      '<li>Reviews and all discussion take place on the Anonymous Versions of your submitted papers.</li>' +
+    '</ul>' +
+  '</p>' +
+  '<br>' +
+  '<h4>Rebuttal Period</h4>' +
+  '<p>' +
+    // '<em><strong>Rebuttal period ends on Friday, October 26</strong></em>:' +
+    '<ul>' +
+      '<li>Authors may revise their paper, but revision history will be available to reviewers.</li>' +
+      '<li>Area chairs and reviewers reserve the right to ignore changes which are significant from the original scope of the paper.</li>' +
+    '</ul>' +
+  '</p><br>'
 
 // Main is the entry point to the webfield code and runs everything
 function main() {

--- a/venues/ICLR.cc/2019/Conference/webfield/reviewerWebfield.js
+++ b/venues/ICLR.cc/2019/Conference/webfield/reviewerWebfield.js
@@ -10,27 +10,27 @@ var INSTRUCTIONS = '<p class="dark">This page provides information and status up
   for ICLR 2019 reviewers. It will be regularly updated as the conference progresses, \
   so please check back frequently for news and other updates.</p>';
 
-var SCHEDULE_HTML = '<h4>Registration Phase</h4>\
-    <p>\
-      <!--<em><strong>Please do the following by Thursday, September 21</strong></em>:-->\
-      <ul>\
-        <li>Update your profile to include your most up-to-date information, including work history and relations, to ensure proper conflict-of-interest detection during the paper matching process.</li> \
-        <!--<li>Complete the ICLR registration form (found in your Tasks view).</li>-->\
-      </ul>\
-    </p>\
-  <br>\
-  <h4>Bidding Phase</h4>\
-    <p>\
-      <!--<em><strong>Please do the following by Monday, Oct 8</strong></em>:\
-      <ul>\
-        <li>Provide your reviewing preferences by bidding on papers using the Bidding Interface.</li>\
-        <li>A URL to the bidding interface will be provided when the Bidding phase starts.</li>\
-        <li><strong><a href="/invitation?id=ICLR.cc/2019/Conference/-/Add_Bid">Go to Bidding Interface</a></strong></li>\
-      </ul>-->\
-      <em><strong>The bidding phase has not started yet.</strong><br/>\
-    This section will be updated once the bidding phase begins.</em>\
-    </p>\
-  <br>'
+var SCHEDULE_HTML = '<h4>Registration Phase</h4>' +
+  '<p>' +
+    // '<em><strong>Please do the following by Thursday, September 21</strong></em>:' +
+    '<ul>' +
+      '<li>Update your profile to include your most up-to-date information, including work history and relations, to ensure proper conflict-of-interest detection during the paper matching process.</li> ' +
+      // '<li>Complete the ICLR registration form (found in your Tasks view).</li>' +
+    '</ul>' +
+  '</p>' +
+  '<br>' +
+  '<h4>Bidding Phase</h4>' +
+  '<p>' +
+    // '<em><strong>Please do the following by Monday, Oct 8</strong></em>:' +
+    // '<ul>' +
+    //   '<li>Provide your reviewing preferences by bidding on papers using the Bidding Interface.</li>' +
+    //   '<li>A URL to the bidding interface will be provided when the Bidding phase starts.</li>' +
+    //   '<li><strong><a href="/invitation?id=ICLR.cc/2019/Conference/-/Add_Bid">Go to Bidding Interface</a></strong></li>' +
+    // '</ul>' +
+    '<em><strong>The bidding phase has not started yet.</strong><br/>' +
+  'This section will be updated once the bidding phase begins.</em>' +
+  '</p>' +
+  '<br>'
 
 
 var CONFERENCE = 'ICLR.cc/2019/Conference';
@@ -94,8 +94,8 @@ var getReviewRatings = function(noteNumbers) {
 
   if (!noteNumbers.length) {
     return $.Deferred().resolve([]);
-  }  
- 
+  }
+
   var dfd = $.Deferred();
 
   var noteMap = buildNoteMap(noteNumbers);
@@ -121,7 +121,7 @@ var getReviewerGroups = function(noteNumbers) {
 
   if (!noteNumbers.length) {
     return $.Deferred().resolve({});
-  } 
+  }
 
   var noteMap = buildNoteMap(noteNumbers);
 
@@ -191,7 +191,7 @@ var getOfficialReviews = function(noteNumbers) {
 
   if (!noteNumbers.length) {
     return $.Deferred().resolve({});
-  }  
+  }
 
   return $.getJSON('notes', { invitation: CONFERENCE + '/-/Paper.*/Official_Review', tauthor: true, noDetails: true })
     .then(function(result) {
@@ -224,7 +224,7 @@ var displayHeader = function(headerP) {
           id: 'assigned-papers',
           content: loadingMessage,
           active: true
-        },        
+        },
         {
           heading: 'Reviewer Schedule',
           id: 'reviewer-schedule',

--- a/venues/auai.org/UAI/2017/webfield/add_bid_invitation_webfield.html
+++ b/venues/auai.org/UAI/2017/webfield/add_bid_invitation_webfield.html
@@ -1,4 +1,3 @@
-<!-- UI for Reviewer Status page -->
 <script type="text/javascript">
 $(function() {
   var CONFERENCE = 'auai.org/UAI/2017';

--- a/venues/auai.org/UAI/2017/webfield/uai2017_webfield.html
+++ b/venues/auai.org/UAI/2017/webfield/uai2017_webfield.html
@@ -1,4 +1,3 @@
-<!-- UAI Homepage -->
 <script type="text/javascript">
 $(function() {
   var SUBJECT_AREAS_LIST = [


### PR DESCRIPTION
Fixes bug where HTML comments would break the quotes and cause a JS syntax error on group pages.