### PR TITLE
Fix/colt allocate reviewer job

### DIFF
--- a/venues/learningtheory.org/COLT/2019/python/allocate-reviewers-job.py
+++ b/venues/learningtheory.org/COLT/2019/python/allocate-reviewers-job.py
@@ -7,33 +7,32 @@ conference = config.get_conference(client)
 reviewer_groups = list(openreview.tools.iterget_groups(client, '{}/Paper.*/Reviewers$'.format(conference.id)))
 
 for r in reviewer_groups:
-    if not any([suffix in r.id for suffix in ['/Invited', '/Declined']]):
-        components = r.id.split('/')
-        paper_num_string = components[4]
-        number = int(paper_num_string.replace('Paper',''))
+    components = r.id.split('/')
+    paper_num_string = components[4]
+    number = int(paper_num_string.replace('Paper',''))
 
-        for member in r.members:
-            print(member)
-            assigned_user, assigned_groups = openreview.tools.assign(client=client,
-                conference='learningtheory.org/COLT/2019/Conference',
-                paper_number=number,
-                reviewer_to_add=member,
-                parent_label = 'Reviewers',
-                individual_label = 'AnonReviewer',
-                individual_group_params = {
-                   'readers': [
-                       'learningtheory.org/COLT/2019/Conference',
-                       'learningtheory.org/COLT/2019/Conference/Program_Chairs',
-                       'learningtheory.org/COLT/2019/Conference/Paper{}/Program_Committee'.format(number)
-                   ],
-               },
-                parent_group_params = {
-                   'readers': [
-                       'learningtheory.org/COLT/2019/Conference',
-                       'learningtheory.org/COLT/2019/Conference/Program_Chairs',
-                       'learningtheory.org/COLT/2019/Conference/Paper{}/Program_Committee'.format(number)
-                   ]
-               },
-                use_profile=False)
+    for member in r.members:
+        print(member)
+        assigned_user, assigned_groups = openreview.tools.assign(client=client,
+            conference='learningtheory.org/COLT/2019/Conference',
+            paper_number=number,
+            reviewer_to_add=member,
+            parent_label = 'Reviewers',
+            individual_label = 'AnonReviewer',
+            individual_group_params = {
+                'readers': [
+                    'learningtheory.org/COLT/2019/Conference',
+                    'learningtheory.org/COLT/2019/Conference/Program_Chairs',
+                    'learningtheory.org/COLT/2019/Conference/Paper{}/Program_Committee'.format(number)
+                ],
+            },
+            parent_group_params = {
+                'readers': [
+                    'learningtheory.org/COLT/2019/Conference',
+                    'learningtheory.org/COLT/2019/Conference/Program_Chairs',
+                    'learningtheory.org/COLT/2019/Conference/Paper{}/Program_Committee'.format(number)
+                ]
+            },
+            use_profile=False)
 
-            print('assignment', assigned_user, assigned_groups)
+        print('assignment', assigned_user, assigned_groups)

--- a/venues/learningtheory.org/COLT/2019/python/allocate-reviewers-job.py
+++ b/venues/learningtheory.org/COLT/2019/python/allocate-reviewers-job.py
@@ -4,7 +4,7 @@ import config
 client = openreview.Client()
 conference = config.get_conference(client)
 
-reviewer_groups = list(openreview.tools.iterget_groups(client, '{}/Paper.*/Reviewers'.format(conference.id)))
+reviewer_groups = list(openreview.tools.iterget_groups(client, '{}/Paper.*/Reviewers$'.format(conference.id)))
 
 for r in reviewer_groups:
     if not any([suffix in r.id for suffix in ['/Invited', '/Declined']]):

--- a/venues/learningtheory.org/COLT/2019/python/allocate-reviewers-job.py
+++ b/venues/learningtheory.org/COLT/2019/python/allocate-reviewers-job.py
@@ -4,7 +4,7 @@ import config
 client = openreview.Client()
 conference = config.get_conference(client)
 
-reviewer_groups = client.get_groups('{}/Paper.*/Reviewers'.format(conference.id))
+reviewer_groups = list(openreview.tools.iterget_groups(client, '{}/Paper.*/Reviewers'.format(conference.id)))
 
 for r in reviewer_groups:
     if not any([suffix in r.id for suffix in ['/Invited', '/Declined']]):


### PR DESCRIPTION
1. Used iterget_groups instead of get_groups
2. Corrected regex to eliminate the need for filtering out /Invited and /Declined groups