### PR TITLE
Colt/official review fix

### DIFF
--- a/venues/learningtheory.org/COLT/2019/process/officialReviewProcess.js
+++ b/venues/learningtheory.org/COLT/2019/process/officialReviewProcess.js
@@ -3,7 +3,7 @@
 function(){
     var or3client = lib.or3client;
 
-    var CONFERENCE_ID = 'ICLR.cc/2019/Conference';
+    var CONFERENCE_ID = 'learningtheory.org/COLT/2019/Conference';
 
     var origNote = or3client.or3request(or3client.notesUrl+'?id='+note.forum, {}, 'GET', token);
     var list = note.invitation.replace(/_/g,' ').split('/');
@@ -14,11 +14,11 @@ function(){
       var forum = result.notes[0];
       var note_number = forum.number;
 
-      var reviewers = [CONFERENCE_ID + '/Paper' + note_number + '/Reviewers'];
-      var areachairs = [CONFERENCE_ID + '/Paper' + note_number + '/Area_Chairs'];
+      var pcMembers = [CONFERENCE_ID + '/Paper' + note_number + '/Program_Committee'];
+      // var areachairs = [CONFERENCE_ID + '/Paper' + note_number + '/Area_Chairs'];
       var authors = forum.content.authorids;
 
-      var areachair_mail = {
+      var pc_mail = {
         "groups": areachairs,
         "subject": "Review posted to your assigned paper: \"" + forum.content.title + "\"",
         "message": "A submission to " + conference + ", for which you are an official area chair, has received an official review. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.review + "\n\nTo view the review, click here: " + baseUrl + "/forum?id=" + note.forum

--- a/venues/learningtheory.org/COLT/2019/process/officialReviewProcess.js
+++ b/venues/learningtheory.org/COLT/2019/process/officialReviewProcess.js
@@ -1,33 +1,25 @@
-//EDIT ME
-
 function(){
-    var or3client = lib.or3client;
+  var or3client = lib.or3client;
 
-    var CONFERENCE_ID = 'learningtheory.org/COLT/2019/Conference';
+  var CONFERENCE_ID = 'learningtheory.org/COLT/2019/Conference';
+  var PAPER_PROGRAM_COMMITTEE;
 
-    var origNote = or3client.or3request(or3client.notesUrl+'?id='+note.forum, {}, 'GET', token);
-    var list = note.invitation.replace(/_/g,' ').split('/');
-    list.splice(list.indexOf('-',1));
-    var conference = list.join(' ');
+  var forumNote = or3client.or3request(or3client.notesUrl+'?id='+note.forum, {}, 'GET', token);
 
-    origNote.then(function(result) {
-      var forum = result.notes[0];
-      var note_number = forum.number;
-
-      var pcMembers = [CONFERENCE_ID + '/Paper' + note_number + '/Program_Committee'];
-      // var areachairs = [CONFERENCE_ID + '/Paper' + note_number + '/Area_Chairs'];
-      var authors = forum.content.authorids;
-
-      var pc_mail = {
-        "groups": areachairs,
-        "subject": "Review posted to your assigned paper: \"" + forum.content.title + "\"",
-        "message": "A submission to " + conference + ", for which you are an official area chair, has received an official review. \n\nTitle: " + note.content.title + "\n\nComment: " + note.content.review + "\n\nTo view the review, click here: " + baseUrl + "/forum?id=" + note.forum
-      };
-      var areachairMailP = or3client.or3request( or3client.mailUrl, areachair_mail, 'POST', token );
-
-      return areachairMailP;
-    })
-    .then(result => done())
-    .catch(error => done(error));
-    return true;
-  };
+  forumNote.then(function(result) {
+    var forum = result.notes[0];
+    var note_number = forum.number;
+    PAPER_PROGRAM_COMMITTEE = CONFERENCE_ID + '/Paper' + note_number + '/Program_Committee';
+  })
+  .then(result => {
+    console.log('attempting to add to group ' + PAPER_PROGRAM_COMMITTEE + '/Submitted');
+    return or3client.addGroupMember(PAPER_PROGRAM_COMMITTEE + '/Submitted', note.signatures[0], token);
+  })
+  .then(result => {
+    console.log('attempting to remove from group ' + PAPER_PROGRAM_COMMITTEE + '/Unubmitted');
+    return or3client.removeGroupMember(PAPER_PROGRAM_COMMITTEE + '/Unsubmitted', note.signatures[0], token);
+  })
+  .then(result => done())
+  .catch(error => done(error));
+  return true;
+};

--- a/venues/learningtheory.org/COLT/2019/python/update-official-review-invi.py
+++ b/venues/learningtheory.org/COLT/2019/python/update-official-review-invi.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
             },
             'signatures': {
                 'description': 'How your identity will be displayed with the above content.',
-                'values-regex': conference.id + '/Paper<number>/AnonReviewer[0-9]+|' + conference.id + '/Paper<number>/Program_Committee_Member[0-9]+'
+                'values-regex': conference.id + '/Paper<number>/AnonReviewer[0-9]*|' + conference.id + '/Paper<number>/Program_Committee_Member[0-9]*'
             },
             'writers': {
                 'description': 'Users that may modify this record.',
@@ -50,8 +50,7 @@ if __name__ == '__main__':
             'nonreaders': {
                 'description': 'Users not allowed to read the reply',
                 'values': [
-                    #  change below group to prog_committee/unsubmitted
-                    conference.id + '/Paper<number>/Program_Committee/Program_Committee_Member3'
+                    conference.id + '/Paper<number>/Program_Committee/Unsubmitted'
                 ]
             },
             'content': openreview.invitations.content.review

--- a/venues/learningtheory.org/COLT/2019/python/update-official-review-invi.py
+++ b/venues/learningtheory.org/COLT/2019/python/update-official-review-invi.py
@@ -1,0 +1,71 @@
+import openreview
+import config
+import argparse
+
+
+if __name__ == '__main__':
+    ## Argument handling
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--baseurl', help="base url")
+    parser.add_argument('--username')
+    parser.add_argument('--password')
+    args = parser.parse_args()
+
+    client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+    conference = config.get_conference(client)
+
+    official_review_template = {
+        'id': conference.id + '/-/Paper<number>/Official_Review',
+        'readers': ['everyone'],
+        'writers': [conference.id],
+        'invitees': [
+            conference.id + '/Paper<number>/Reviewers', 
+            conference.id + '/Paper<number>/Program_Committee'],
+        'noninvitees': [],
+        'signatures': [conference.id],
+        'duedate': openreview.tools.timestamp_GMT(year=2019, month=3, day=21, hour=7),
+        'multiReply': False,
+        'process' : None,
+        'reply': {
+            'forum': '<forum>',
+            'replyto': '<forum>',
+            'readers': {
+                'description': 'The users who will be allowed to read the reply content.',
+                'values': [
+                    conference.id + '/Paper<number>/Program_Committee',
+                    conference.id + '/Program_Chairs'
+                    ]
+            },
+            'signatures': {
+                'description': 'How your identity will be displayed with the above content.',
+                'values-regex': conference.id + '/Paper<number>/AnonReviewer[0-9]+|' + conference.id + '/Paper<number>/Program_Committee_Member[0-9]+'
+            },
+            'writers': {
+                'description': 'Users that may modify this record.',
+                'values-copied':  [
+                    conference.id,
+                    '{signatures}'
+                ]
+            },
+            'nonreaders': {
+                'description': 'Users not allowed to read the reply',
+                'values': [
+                    #  change below group to prog_committee/unsubmitted
+                    conference.id + '/Paper<number>/Program_Committee/Program_Committee_Member3'
+                ]
+            },
+            'content': openreview.invitations.content.review
+        }
+    }
+    with open('../process/officialReviewProcess.js', 'r') as f:
+        official_review_template['process'] = f.read()
+    blind_notes = list(openreview.tools.iterget_notes(client, invitation=conference.get_id() + '/-/Blind_Submission'))
+    for index, note in enumerate(blind_notes):
+        official_review_invitation = client.post_invitation(
+            openreview.Invitation.from_json(
+                openreview.tools.fill_template(official_review_template, note)
+            )
+        )
+        if (index+1)%10 == 0 :
+            print ('Processed ', index+1)
+    print ('Processed ', index+1)


### PR DESCRIPTION
with this the program committee members get appropriate readership for review comments. 
- Yet to implement readership permissions based on sub-reviewers having submitted reviews.
- Also, this does not take care of sub-reviewer being able to read other's reviews.