### PR TITLE
job to move pc members to submitted

### DIFF
--- a/venues/learningtheory.org/COLT/2019/python/move-pc-members-to-submitted-job.py
+++ b/venues/learningtheory.org/COLT/2019/python/move-pc-members-to-submitted-job.py
@@ -1,0 +1,55 @@
+from __future__ import print_function, unicode_literals
+import argparse
+import openreview
+import openreview.tools as tools
+
+## Argument handling
+parser = argparse.ArgumentParser()
+parser.add_argument('--baseurl', help="base url")
+parser.add_argument('--username')
+parser.add_argument('--password')
+parser.add_argument('--tcdate')
+
+args = parser.parse_args()
+
+client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+conference = 'learningtheory.org/COLT/2019/Conference'
+
+def run(args):
+    new_official_reviews = list(openreview.tools.iterget_notes(client, invitation = conference+'/-/Paper.*/Official_Review', mintcdate = args.tcdate))
+    
+    for review in new_official_reviews:
+        if 'AnonReviewer' in review.signatures[0]:
+            invited_reviewer = client.get_group(review.signatures[0]).members[0]
+            paper_number = review.signatures[0].split('Paper')[1].split('/')[0]
+            acceptance_notes = client.get_notes(
+                invitation = conference + '/Program_Committee/-/Paper' + paper_number + '/Recruit_Reviewers')
+            
+            # If multiple PC members invited the same subreviewer, we mark all the PC members as Submitted
+            submitted_pc_members = []
+            for accept_note in acceptance_notes:
+                if (accept_note.content['email'] == invited_reviewer and accept_note.content['response'] == 'Yes'):
+                    submitted_pc_members.append(accept_note.content['invitedBy'])
+            
+            submitted_pc_anon_groups = []
+            for pc in submitted_pc_members:
+                grp = client.get_groups(
+                    regex = conference + '/Paper' + paper_number +'/Program_Committee_Member[0-9]*',
+                    member = pc)
+                if len(grp):
+                    submitted_pc_anon_groups.append(grp[0].id)
+            
+            if (len(submitted_pc_anon_groups)):
+                pc_submitted_group = client.get_group(id = conference + '/Paper' + paper_number + '/Program_Committee/Submitted')
+                pc_unsubmitted_group = client.get_group(id = conference + '/Paper' + paper_number + '/Program_Committee/Unsubmitted')
+
+                # Adding members to group: submitted_pc_anon_groups
+                client.add_members_to_group(pc_submitted_group, submitted_pc_anon_groups)
+                # Removing members from group: submitted_pc_anon_groups
+                client.remove_members_from_group(pc_unsubmitted_group, submitted_pc_anon_groups)
+
+def main():
+    run(args)
+
+if __name__ == "__main__":
+    main()

--- a/venues/learningtheory.org/COLT/2019/python/move-pc-members-to-submitted-job.py
+++ b/venues/learningtheory.org/COLT/2019/python/move-pc-members-to-submitted-job.py
@@ -18,7 +18,7 @@ conference = 'learningtheory.org/COLT/2019/Conference'
 def run(args):
     new_official_reviews = list(openreview.tools.iterget_notes(client, invitation = conference+'/-/Paper.*/Official_Review', mintcdate = args.tcdate))
     
-    for index, review in enumerate(new_official_reviews):
+    for review in new_official_reviews:
         if 'AnonReviewer' in review.signatures[0]:
             invited_reviewer = client.get_group(review.signatures[0]).members[0]
             paper_number = review.signatures[0].split('Paper')[1].split('/')[0]
@@ -50,17 +50,19 @@ def run(args):
                 client.remove_members_from_group(pc_unsubmitted_group, submitted_pc_anon_groups)
             
             # Modifying the sub-reviewer's review to be editable by the inviting PC member
+            copy_review_writers = submitted_pc_anon_groups[:]
+            copy_review_writers.append(conference + '/Program_Chairs')
             review_copy =  openreview.Note(
                 invitation = review.invitation,
                 forum = review.forum,
                 signatures = submitted_pc_anon_groups,
-                writers = submitted_pc_anon_groups,
+                writers = copy_review_writers,
                 readers = review.readers,
                 nonreaders = review.nonreaders,
                 content = review.content
             )
             posted_review_copy = client.post_note(review_copy)
-            print ('Processed ', index)
+            print ('Processed the official reviewe with id: ', review.id)
 
 def main():
     run(args)

--- a/venues/learningtheory.org/COLT/2019/python/move-pc-members-to-submitted-job.py
+++ b/venues/learningtheory.org/COLT/2019/python/move-pc-members-to-submitted-job.py
@@ -62,7 +62,7 @@ def run(args):
                 content = review.content
             )
             posted_review_copy = client.post_note(review_copy)
-            print ('Processed the official reviewe with id: ', review.id)
+            print ('Processed the official review with id: ', review.id)
 
 def main():
     run(args)

--- a/venues/learningtheory.org/COLT/2019/python/move-pc-members-to-submitted-job.py
+++ b/venues/learningtheory.org/COLT/2019/python/move-pc-members-to-submitted-job.py
@@ -16,9 +16,9 @@ client = openreview.Client(baseurl=args.baseurl, username=args.username, passwor
 conference = 'learningtheory.org/COLT/2019/Conference'
 
 def run(args):
-    new_official_reviews = list(openreview.tools.iterget_notes(client, invitation = conference+'/-/Paper[0-9]*/Official_Review', mintcdate = args.tcdate))
+    new_official_reviews = list(openreview.tools.iterget_notes(client, invitation = conference+'/-/Paper.*/Official_Review', mintcdate = args.tcdate))
     
-    for review in new_official_reviews:
+    for index, review in enumerate(new_official_reviews):
         if 'AnonReviewer' in review.signatures[0]:
             invited_reviewer = client.get_group(review.signatures[0]).members[0]
             paper_number = review.signatures[0].split('Paper')[1].split('/')[0]
@@ -60,6 +60,7 @@ def run(args):
                 content = review.content
             )
             posted_review_copy = client.post_note(review_copy)
+            print ('Processed ', index)
 
 def main():
     run(args)


### PR DESCRIPTION
This job moves PC members to _Paper[0-9]+/Program_Committee/Submitted_ group if their invited sub-reviewer has submitted a review. It also removes the appropriate _Paper[0-9]+/Program_Commitee_Member[0-9]+_ group from the _Paper[0-9]+/Program_Committee/Unsubmitted_ group