### PR TITLE
Colt19/subreviewer add to reviewer invited

### DIFF
--- a/venues/learningtheory.org/COLT/2019/python/init.py
+++ b/venues/learningtheory.org/COLT/2019/python/init.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
         client.post_group(program_chair_group)
 
     area_chairs_group = conference.set_area_chairs(emails=[])
-    with open(os.path.abspath('../webfield/programCommitteeWebfield_init.js')) as f:
+    with open(os.path.abspath('../webfield/programCommitteeWebfield_bidding-stage.js')) as f:
         area_chairs_group.web = f.read()
         area_chairs_group.signatories.append(area_chairs_group.id)
         client.post_group(area_chairs_group)

--- a/venues/learningtheory.org/COLT/2019/webfield/programCommitteeWebfield_bidding-stage.js
+++ b/venues/learningtheory.org/COLT/2019/webfield/programCommitteeWebfield_bidding-stage.js
@@ -899,6 +899,11 @@ var inviteReviewer = function(invididualGroupId, noteId, noteNumber, noteName, r
       members: [reviewer] });
   })
   .then(function(response) {
+    return Webfield.put('/groups/members', {
+      id: 'learningtheory.org/COLT/2019/Conference/Paper' + noteNumber + '/Reviewers/Invited',
+      members: [reviewer] });
+  })
+  .then(function(response) {
     console.log('User added to invited group');
     promptMessage('An invitation email was sent to ' + reviewer);
     done();


### PR DESCRIPTION
Update to programchairWebfield to add the subreviewer being invited to /Reviewers/Invited groups. This is so that they can read the blind note (of the paper they are getting invited to) without accepting the review invitation.