### PR TITLE
Uai2019/withdraw submission

### DIFF
--- a/venues/auai.org/UAI/2019/Conference/process/withdrawProcess.js
+++ b/venues/auai.org/UAI/2019/Conference/process/withdrawProcess.js
@@ -1,0 +1,45 @@
+function(){
+  var or3client = lib.or3client;
+
+  var CONFERENCE_ID = 'auai.org/UAI/2019/Conference';
+  var SHORT_PHRASE = "UAI 2019";
+  
+  var forumNoteP = or3client.or3request(or3client.notesUrl + '?id=' + note.forum, {}, 'GET', token);
+
+  forumNoteP.then(function(result) {
+    var forumNote = result.notes[0];
+
+    var author_mail = {
+      'groups': forumNote.content.authorids,
+      'subject': SHORT_PHRASE + ' : Notification of withdrawal of your submission "' + forumNote.content.title + '"',
+      'message': 'Your submission, "' + forumNote.content.title + '", has been withdrawn by one of the authors. \
+      To view your withdrawn submission, click here: ' + baseUrl + '/forum?id=' + forumNote.forum + '\n\n\
+      The record of this submission (including all existing reviews and comments) \
+      will remain on OpenReview visible only to the Authors of this paper and the Program Chairs.\n\n\
+      If you believe that this withdrawal was an error, please contact info@openreview.net as soon as possible.'
+    };
+
+    var current_timestamp = Date.now();
+
+    forumNote.invitation = CONFERENCE_ID + '/-/Withdrawn_Submission';
+    forumNote.readers = [CONFERENCE_ID + '/Program_Chairs', forumNote.content.authorids[0]];
+    forumNote.content = {
+      'authors': forumNote.content.authors,
+      'authorids': forumNote.content.authorids
+    };
+    return or3client.or3request(or3client.notesUrl, forumNote , 'POST', token)
+    .then(result => or3client.or3request(or3client.mailUrl, author_mail, 'POST', token))
+    .then(result => {
+      return or3client.or3request(or3client.inviteUrl + '?id=' + CONFERENCE_ID + '/-/Paper' + forumNote.number + '/Revision', {}, 'GET', token)
+      .then(result => {
+        var revisionInvitation = result.invitations[0];
+        revisionInvitation.expdate = current_timestamp;
+        return or3client.or3request(or3client.inviteUrl, revisionInvitation, 'POST', token);
+      })
+    })
+  })
+  .then(result => done())
+  .catch(error => done(error));
+
+  return true;
+};

--- a/venues/auai.org/UAI/2019/Conference/python/create-withdraw-invitations.py
+++ b/venues/auai.org/UAI/2019/Conference/python/create-withdraw-invitations.py
@@ -1,0 +1,101 @@
+import argparse
+import openreview
+from openreview import invitations
+import datetime
+import os
+import config
+
+withdrawal_statement = 'On behalf of the authors of this paper, \
+I hereby withdraw this submission from consideration for UAI 2019. \
+I understand that this cannot be undone, \
+and that the record of this submission (including all existing reviews and comments) \
+will remain on OpenReview visible only to the paper authors and program chairs.'
+
+if __name__ == '__main__':
+    ## Argument handling
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--baseurl', help="base url")
+    parser.add_argument('--username')
+    parser.add_argument('--password')
+    args = parser.parse_args()
+
+    client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+    conference = config.get_conference(client)
+    
+    # This is the Conference level Invitation for all withdrawn submissions
+    withdrawn_submission_invitation = client.post_invitation(openreview.Invitation(
+        id = conference.get_id() + "/-/Withdrawn_Submission",
+        readers = ['everyone'],
+        writers = [conference.get_id()],
+        invitees = [conference.get_id()],
+        noninvitees = [],
+        signatures = [conference.get_id()],
+        reply = {
+           'forum': None,
+           'replyto': None,
+           'readers': {
+               'description': 'The users who will be allowed to read the reply content.',
+               'values-regex': conference.get_program_chairs_id() + '|' + conference.get_id() + '/Paper[0-9]*/Authors'
+           },
+           'signatures': {
+               'description': 'How your identity will be displayed with the above content.',
+               'values': [conference.get_id()]
+           },
+           'writers': {
+               'description': 'Users that may modify this record.',
+               'values':  [conference.get_id()]
+           },
+           'content': {}
+        },
+        nonreaders = []
+    ))
+
+    # Template for per-paper withdraw submission invitation
+    withdraw_submission_template = {
+        'id': conference.get_id() + '/-/Paper<number>/Withdraw_Submission',
+        'readers': ['everyone'],
+        'writers': [conference.get_id()],
+        'invitees': [conference.get_id() + '/Paper<number>/Authors'],
+        'signatures': ['OpenReview.net'],
+        'multiReply': False,
+        'reply': {
+            'forum': '<forum>',
+            'replyto': '<forum>',
+            'readers': {
+                'description': 'Select all user groups that should be able to read this comment.',
+                'values': [conference.get_program_chairs_id(), conference.get_id() + '/Paper<number>/Authors']
+            },
+            'signatures': {
+                'description': '',
+                'values-regex': conference.get_id()+'/Paper<number>/Authors',
+            },
+            'writers': {
+                'description': 'Users that may modify this record.',
+                'values':  [conference.get_id()]
+            },
+            'content': {
+                'title': {
+                    'value': 'Submission Withdrawn by the Authors',
+                    'order': 1
+                },
+                'withdrawal confirmation': {
+                    'description': withdrawal_statement,
+                    'value-radio': ['I have read and agree with the withdrawal statement on behalf of myself and my co-authors.'],
+                    'order': 2,
+                    'required': True
+                }
+            }
+        }
+    }
+    with open(os.path.abspath('../process/withdrawProcess.js')) as f:
+        withdraw_submission_template['process'] = f.read()
+    
+    blind_notes = openreview.tools.iterget_notes(client, invitation=conference.get_blind_submission_id())
+    for index, note in enumerate(blind_notes):
+        client.post_invitation(openreview.Invitation.from_json(
+            openreview.tools.fill_template(withdraw_submission_template, note)
+        ))
+        if (index+1)%10 == 0:
+            print ('Processed ', index+1)
+    
+    print ('Processed ', index+1)


### PR DESCRIPTION
Process function withdraw does these 3 things:
1. Updates the blind note's invitation to conference level withdraw invitation and sets the note's readers to Program Chairs and Paper authors.
2. Sends email to the paper authors notifying about the submission withdrawal.
3. Expires the per-paper Revision invitation