### PR TITLE
Support/revision python process

### DIFF
--- a/venues/OpenReview.net/Support/build-venue.py
+++ b/venues/OpenReview.net/Support/build-venue.py
@@ -38,7 +38,7 @@ You can use the following links to access to the conference:
 Conference home page: https://openreview.net/group?id={conference_id}
 Conference Program Chairs console: https://openreview.net/group?id={program_chairs_id}
 
-If you need to make a change to the information provided in your request form, please edit it directly. We will update your venue accordingly.
+If you need to make a change to the information provided in your request form, please edit/revise it directly. We will update your venue accordingly.
 
 If you need special features that are not included in your request form, you can create a comment here or contact us at info@openreview.net and we will assist you.
 

--- a/venues/OpenReview.net/Support/deployProcess.py
+++ b/venues/OpenReview.net/Support/deployProcess.py
@@ -41,8 +41,14 @@ OpenReview Team
         )
         client.post_note(comment_note)
 
-        revision_invitation = client.get_invitation('OpenReview.net/Support/-/Request' + str(forum.number) + '/Revision')
-        revision_invitation.signatures = [conference.get_program_chairs_id()]
+        revision_invitation = client.get_invitation(id= 'OpenReview.net/Support/-/Request' + str(forum.number) + '/Revision')
+        revision_invitation.reply['readers'] = {
+            'values':  readers
+        }
+        revision_invitation.invitees = readers
         client.post_invitation(revision_invitation)
+
+        forum.writers = ['OpenReview.net']
+        client.post_note(forum)
 
     print('Conference: ', conference.get_id())

--- a/venues/OpenReview.net/Support/deployProcess.py
+++ b/venues/OpenReview.net/Support/deployProcess.py
@@ -41,4 +41,8 @@ OpenReview Team
         )
         client.post_note(comment_note)
 
+        revision_invitation = client.get_invitation('OpenReview.net/Support/-/Request' + str(forum.number) + '/Revision')
+        revision_invitation.signatures = [conference.get_program_chairs_id()]
+        client.post_invitation(revision_invitation)
+
     print('Conference: ', conference.get_id())

--- a/venues/OpenReview.net/Support/deployProcess.py
+++ b/venues/OpenReview.net/Support/deployProcess.py
@@ -1,0 +1,44 @@
+def process(client, note, invitation):
+    print('client:', client.baseurl)
+    print('note:', note.id)
+    print('invitation:', invitation.id)
+    conference = openreview.helpers.get_conference(client, note.forum)
+    print(conference.get_id())
+    if conference.is_new():
+        forum = client.get_note(id=note.forum)
+        readers = forum.content['Contact Emails']
+        readers.append('OpenReview.net/Support')
+        comment_note = openreview.Note(
+            invitation = 'OpenReview.net/Support/-/Request' + str(forum.number) + '/Comment',
+            forum = forum.id,
+            replyto = forum.id,
+            readers = readers,
+            writers = ['OpenReview.net/Support'],
+            signatures = ['OpenReview.net/Support'],
+            content = {
+                'title': 'Your venue is available in OpenReview',
+                'comment': '''
+Hi Program Chairs,
+
+Thanks for submitting a venue request.
+
+We have set up the venue based on the information that you provided here: https://openreview.net/forum?id={noteId}
+
+You can use the following links to access to the conference:
+
+Conference home page: https://openreview.net/group?id={conference_id}
+Conference Program Chairs console: https://openreview.net/group?id={program_chairs_id}
+
+If you need to make a change to the information provided in your request form, please edit it directly. We will update your venue accordingly.
+
+If you need special features that are not included in your request form, you can create a comment here or contact us at info@openreview.net and we will assist you.
+
+Thanks!
+
+OpenReview Team
+                '''.format(noteId = forum.id, conference_id = conference.get_id(), program_chairs_id = conference.get_program_chairs_id())
+            }
+        )
+        client.post_note(comment_note)
+
+    print('Conference: ', conference.get_id())

--- a/venues/OpenReview.net/Support/deployProcess.py
+++ b/venues/OpenReview.net/Support/deployProcess.py
@@ -29,7 +29,7 @@ You can use the following links to access to the conference:
 Conference home page: https://openreview.net/group?id={conference_id}
 Conference Program Chairs console: https://openreview.net/group?id={program_chairs_id}
 
-If you need to make a change to the information provided in your request form, please edit it directly. We will update your venue accordingly.
+If you need to make a change to the information provided in your request form, please edit/revise it directly. We will update your venue accordingly.
 
 If you need special features that are not included in your request form, you can create a comment here or contact us at info@openreview.net and we will assist you.
 

--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -20,47 +20,35 @@ support = openreview.Group(**{
     'web': './supportRequestsWeb.js'
 })
 
-reader_options = [
-    'Program Chairs',
-    'Assigned Area Chairs/Metareviewers',
-    'Assigned Reviewers',
-    'All Area Chairs/Metareviewers',
-    'All Reviewers',
-    'All Authors',
-    'Everyone directly involved in the Conference',
-    'Logged-in OpenReview Users',
-    'General Public',
-    'Other'
-]
-
 request_content = {
     'title': {
         'value-copied': '{content[\'Official Conference Name\']}',
-        'description': 'Used for display purposes. Will be copied from the Official Conference Name'
+        'description': 'Used for display purposes. Will be copied from the Official Conference Name',
+        'order': 1
     },
     'Official Conference Name': {
         'description': 'This will appear on your conference\'s OpenReview page. Example: "Seventh International Conference on Learning Representations"',
         'value-regex': '.*',
         'required': True,
-        'order': 1
+        'order': 2
     },
     'Abbreviated Conference Name': {
         'description': 'Please include the year as well. This will be used to identify your conference on OpenReview and in email subject lines. Example: "ICLR 2019"',
         'value-regex': '.*',
         'required': True,
-        'order': 2
+        'order': 3
     },
     'Official Website URL': {
         'description': 'Please provide the official website URL of the conference.',
         'value-regex': '.*',
         'required': True,
-        'order': 3
+        'order': 4
     },
     'Contact Emails': {
         'description': 'Please provide the email addresses of all the Program Chairs or Organizers (comma-separated)',
         'values-regex': '.*',
         'required': True,
-        'order': 4
+        'order': 5
     },
     'Area Chairs (Metareviewers)': {
         'description': 'Does your conference have Area Chairs?',
@@ -70,27 +58,27 @@ request_content = {
             'Other (describe below)'
         ],
         'required': True,
-        'order': 5
+        'order': 6
     },
     'Submission Start Date': {
         'description': 'When would you (ideally) like to have your OpenReview submission portal opened? Please submit in the following format: YYYY/MM/DD HH:MM(e.g. 2019/01/31 23:59). (Skip this if only requesting paper matching service)',
         'value-regex': '.*',
-        'order': 6
+        'order': 7
     },
     'Submission Deadline': {
         'value-regex': '.*',
         'description': 'By when do authors need to submit their manuscripts? Please submit in the following format: YYYY/MM/DD HH:MM(e.g. 2019/01/31 23:59)',
-        'order': 7
+        'order': 8
     },
     'Conference Start Date': {
         'description': 'What is the start date of conference itself? Please submit in the following format: YYYY/MM/DD (e.g. 2019/01/31)',
         'value-regex': '.*',
-        'order': 8
+        'order': 9
     },
     'Conference Location': {
         'description': 'Where the conference is going to be held. For example: Amherst, Massachusetts, United States',
         'value-regex': '.*',
-        'order': 9
+        'order': 10
     },
     'Paper Matching': {
         'description': 'Choose options for assigning papers to reviewers. If using the OpenReview Paper Matching System, see the top of the page for a description of each feature type.',
@@ -102,7 +90,7 @@ request_content = {
             'TPMS',
             'Other (describe below)'
         ],
-        'order': 10
+        'order': 11
     },
     'Author and Reviewer Anonymity': {
         'description': 'What policy best describes your anonymity policy? (Select "Other" if none apply, and describe your request below)',
@@ -112,7 +100,7 @@ request_content = {
             'No anonymity',
             'Other (describe below)'
         ],
-        'order': 11
+        'order': 12
     },
     'Open Reviewing Policy': {
         'description': 'Should submitted papers and/or reviews be visible to the public? (This is independent of anonymity policy)',
@@ -122,7 +110,7 @@ request_content = {
             'Submissions and reviews should both be private.',
             'Other (describe below)'
         ],
-        'order': 12
+        'order': 13
     },
     'Public Commentary': {
         'description': 'Would you like to allow members of the public to comment on papers?',
@@ -132,17 +120,17 @@ request_content = {
             'No, do not allow public commentary.',
             'Other (describe below)'
         ],
-        'order': 13
+        'order': 14
     },
     'Other Important Information': {
         'value-regex': '[\\S\\s]{1,5000}',
         'description': 'Please use this space to clarify any questions above for which you responded "Other", and to clarify any other information that you think we may need.',
-        'order': 14
+        'order': 15
     },
     'How did you hear about us?': {
         'value-regex': '.*',
         'description': 'Please briefly describe how you heard about OpenReview.',
-        'order': 15
+        'order': 16
     }
 }
 
@@ -162,10 +150,14 @@ request_inv = client.post_invitation(openreview.Invitation(**{
             ]
         },
         'writers': {
-            'values': ['OpenReview.net/Support'],
+            'values-copied': [
+                'OpenReview.net/Support',
+                '{signatures}',
+                '{content["Contact Emails"]}'
+            ]
         },
         'signatures': {
-            'values-regex': '~.*'
+            'values-regex': '~.*|OpenReview.net/Support'
         },
         'content': request_content
     }
@@ -248,10 +240,7 @@ deploy_inv = client.post_invitation(openreview.Invitation(**{
     'multiReply': False,
     'reply': {
         'readers': {
-            'values-copied': [
-                'OpenReview.net/Support',
-                '{content["Contact Emails"]}'
-            ]
+            'values': ['OpenReview.net/Support']
         },
         'writers': {
             'values-regex': '~.*',

--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -150,13 +150,14 @@ request_inv = client.post_invitation(openreview.Invitation(**{
     'id': 'OpenReview.net/Support/-/Request_Form',
     'readers': ['everyone'],
     'writers': [],
-    'signatures': ['OpenReview.net/Support'],
+    'signatures': ['OpenReview.net'],
     'invitees': ['everyone'],
     'process': 'supportProcess.js',
     'reply': {
         'readers': {
             'values-copied': [
                 'OpenReview.net/Support',
+                '{signatures}',
                 '{content["Contact Emails"]}'
             ]
         },

--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -235,8 +235,8 @@ revision_inv = client.post_invitation(openreview.Invitation(**{
     }
 }))
 
-deploy_content = {'conference_id': {
-    'value-regex': '.*', 'description': 'Conference id'}}
+deploy_content = {'venue_id': {
+    'value-regex': '.*', 'description': 'Venue id'}}
 
 deploy_inv = client.post_invitation(openreview.Invitation(**{
     'id': 'OpenReview.net/Support/-/Deploy',
@@ -245,6 +245,7 @@ deploy_inv = client.post_invitation(openreview.Invitation(**{
     'signatures': ['OpenReview.net/Support'],
     'invitees': ['OpenReview.net/Support'],
     'process': 'deployProcess.py',
+    'multiReply': False,
     'reply': {
         'readers': {
             'values-copied': [

--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -217,6 +217,7 @@ revision_inv = client.post_invitation(openreview.Invitation(**{
     'writers': [],
     'signatures': ['OpenReview.net/Support'],
     'invitees': ['everyone'],
+    'process': 'revisionProcess.py',
     'reply': {
         'readers': {
             'values-copied': [
@@ -237,12 +238,13 @@ revision_inv = client.post_invitation(openreview.Invitation(**{
 deploy_content = {'conference_id': {
     'value-regex': '.*', 'description': 'Conference id'}}
 
-admin_revision_inv = client.post_invitation(openreview.Invitation(**{
+deploy_inv = client.post_invitation(openreview.Invitation(**{
     'id': 'OpenReview.net/Support/-/Deploy',
     'readers': ['everyone'],
     'writers': [],
     'signatures': ['OpenReview.net/Support'],
     'invitees': ['OpenReview.net/Support'],
+    'process': 'deployProcess.py',
     'reply': {
         'readers': {
             'values-copied': [
@@ -262,4 +264,4 @@ admin_revision_inv = client.post_invitation(openreview.Invitation(**{
 
 client.post_invitation(request_inv)
 client.post_invitation(revision_inv)
-client.post_invitation(admin_revision_inv)
+client.post_invitation(deploy_inv)

--- a/venues/OpenReview.net/Support/revisionProcess.py
+++ b/venues/OpenReview.net/Support/revisionProcess.py
@@ -1,6 +1,3 @@
 def process(client, note, invitation):
-    print('client:', client.baseurl)
-    print('note:', note.id)
-    print('invitation:', invitation.id)
     conference = openreview.helpers.get_conference(client, note.forum)
     print('Conference: ', conference.get_id())

--- a/venues/OpenReview.net/Support/revisionProcess.py
+++ b/venues/OpenReview.net/Support/revisionProcess.py
@@ -3,34 +3,4 @@ def process(client, note, invitation):
     print('note:', note.id)
     print('invitation:', invitation.id)
     conference = openreview.helpers.get_conference(client, note.forum)
-    forum = client.get_note(note.forum)
-    if 'conference_id' in forum.content:
-        # This means that we just updated a live venue
-        readers = forum.content['Contact Emails']
-        readers.append('OpenReview.net/Support')
-        comment_note = openreview.Note(
-            invitation = 'OpenReview.net/Support/-/Request' + str(forum.number) + '/Comment',
-            forum = forum.id,
-            replyto = forum.id,
-            readers = readers,
-            writers = ['OpenReview.net/Support'],
-            signatures = ['OpenReview.net/Support'],
-            content = {
-                'title': 'Your venue has been updated',
-                'comment': '''
-Hi Program Chairs,
-
-We have updated the venue based on the updated information that you provided here: https://openreview.net/forum?id={noteId} .
-
-If you need to make a change to the venue, please edit the information provided in your request form directly. We will update your venue accordingly.
-
-If you need special features that are not included in your request form, you can create a comment here or contact us at info@openreview.net and we will assist you.
-
-Thanks!
-
-OpenReview Team'''.format(noteId = forum.id)
-            }
-        )
-        client.post_note(comment_note)
-
     print('Conference: ', conference.get_id())

--- a/venues/OpenReview.net/Support/revisionProcess.py
+++ b/venues/OpenReview.net/Support/revisionProcess.py
@@ -1,0 +1,36 @@
+def process(client, note, invitation):
+    print('client:', client.baseurl)
+    print('note:', note.id)
+    print('invitation:', invitation.id)
+    conference = openreview.helpers.get_conference(client, note.forum)
+    forum = client.get_note(note.forum)
+    if 'conference_id' in forum.content:
+        # This means that we just updated a live venue
+        readers = forum.content['Contact Emails']
+        readers.append('OpenReview.net/Support')
+        comment_note = openreview.Note(
+            invitation = 'OpenReview.net/Support/-/Request' + str(forum.number) + '/Comment',
+            forum = forum.id,
+            replyto = forum.id,
+            readers = readers,
+            writers = ['OpenReview.net/Support'],
+            signatures = ['OpenReview.net/Support'],
+            content = {
+                'title': 'Your venue has been updated',
+                'comment': '''
+Hi Program Chairs,
+
+We have updated the venue based on the updated information that you provided here: https://openreview.net/forum?id={noteId} .
+
+If you need to make a change to the venue, please edit the information provided in your request form directly. We will update your venue accordingly.
+
+If you need special features that are not included in your request form, you can create a comment here or contact us at info@openreview.net and we will assist you.
+
+Thanks!
+
+OpenReview Team'''.format(noteId = forum.id)
+            }
+        )
+        client.post_note(comment_note)
+
+    print('Conference: ', conference.get_id())

--- a/venues/OpenReview.net/Support/supportProcess.js
+++ b/venues/OpenReview.net/Support/supportProcess.js
@@ -43,7 +43,7 @@ function(){
       signatures: ['OpenReview.net']
     }
 
-    var reviseInvitationSupportTeam = {
+    var deployInvitation = {
       id: 'OpenReview.net/Support/-/Request' + note.number + '/Deploy',
       super: 'OpenReview.net/Support/-/Deploy',
       reply: {
@@ -57,7 +57,7 @@ function(){
     .then(result => or3client.or3request(or3client.mailUrl, programchairMailPayload, 'POST', token))
     .then(result => or3client.or3request(or3client.inviteUrl, commentInvitation, 'POST', token))
     .then(result => or3client.or3request(or3client.inviteUrl, reviseInvitation, 'POST', token))
-    .then(result => or3client.or3request(or3client.inviteUrl, reviseInvitationSupportTeam, 'POST', token))
+    .then(result => or3client.or3request(or3client.inviteUrl, deployInvitation, 'POST', token))
     .then(result => done())
     .catch(error => done(error));
 

--- a/venues/OpenReview.net/Support/supportProcess.js
+++ b/venues/OpenReview.net/Support/supportProcess.js
@@ -36,6 +36,7 @@ function(){
     var reviseInvitation = {
       id: 'OpenReview.net/Support/-/Request' + note.number + '/Revision',
       super: 'OpenReview.net/Support/-/Revision',
+      invitees: [],
       reply: {
         referent: note.forum,
         forum: note.forum

--- a/venues/OpenReview.net/Support/supportProcess.js
+++ b/venues/OpenReview.net/Support/supportProcess.js
@@ -30,7 +30,7 @@ function(){
             values: note.content['Contact Emails'].concat(['OpenReview.net/Support'])
         }
       },
-      signatures: ['OpenReview.net/Support']
+      signatures: ['OpenReview.net']
     }
 
     var reviseInvitation = {
@@ -40,7 +40,7 @@ function(){
         referent: note.forum,
         forum: note.forum
       },
-      signatures: ['OpenReview.net/Support']
+      signatures: ['OpenReview.net']
     }
 
     var reviseInvitationSupportTeam = {
@@ -50,7 +50,7 @@ function(){
         referent: note.forum,
         forum: note.forum
       },
-      signatures: ['OpenReview.net/Support']
+      signatures: ['OpenReview.net']
     }
 
     or3client.or3request(or3client.mailUrl, openreviewMailPayload, 'POST', token)

--- a/venues/OpenReview.net/Support/supportProcess.js
+++ b/venues/OpenReview.net/Support/supportProcess.js
@@ -30,7 +30,7 @@ function(){
             values: note.content['Contact Emails'].concat(['OpenReview.net/Support'])
         }
       },
-      signatures: ['OpenReview.net']
+      signatures: ['OpenReview.net/Support']
     }
 
     var reviseInvitation = {
@@ -40,7 +40,7 @@ function(){
         referent: note.forum,
         forum: note.forum
       },
-      signatures: ['OpenReview.net']
+      signatures: ['OpenReview.net/Support']
     }
 
     var deployInvitation = {


### PR DESCRIPTION
Once a new request is received on the page https://openreview.net/group?id=OpenReview.net/Support 
 , the support team would see a 'Deploy' button on the request forum allowing them to deploy the venue by providing a conference id.
The authors of the request (program chairs) and the support team will also see a 'Revision' button that would allow updating the support request.
If the venue has already been deployed, the revision would change the field values in the actual venue as well.

Q. I am considering deactivating the 'Deploy' invitation once the conference is deployed. What do you think?

Note: This requires python process support to be deployed on the live site.