### PR TITLE
Fix/support requests

### DIFF
--- a/venues/OpenReview.net/Support/deployProcess.py
+++ b/venues/OpenReview.net/Support/deployProcess.py
@@ -26,8 +26,8 @@ We have set up the venue based on the information that you provided here: https:
 
 You can use the following links to access to the conference:
 
-Conference home page: https://openreview.net/group?id={conference_id}
-Conference Program Chairs console: https://openreview.net/group?id={program_chairs_id}
+Venue home page: https://openreview.net/group?id={conference_id}
+Venue Program Chairs console: https://openreview.net/group?id={program_chairs_id}
 
 If you need to make a change to the information provided in your request form, please edit/revise it directly. We will update your venue accordingly.
 

--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -70,12 +70,12 @@ request_content = {
         'order': 8
     },
     'Venue Start Date': {
-        'description': 'What is the start date of venue itself? Please submit in the following format: YYYY/MM/DD (e.g. 2019/01/31)',
+        'description': 'What date does the venue start? Please submit in the following format: YYYY/MM/DD (e.g. 2019/01/31)',
         'value-regex': '.*',
         'order': 9
     },
     'Location': {
-        'description': 'Where the event is being held. For example: Amherst, Massachusetts, United States',
+        'description': 'Where is the event being held. For example: Amherst, Massachusetts, United States',
         'value-regex': '.*',
         'order': 10
     },

--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -117,15 +117,20 @@ request_content = {
         ],
         'order': 14
     },
+    'Expected Submissions': {
+        'value-regex': '[0-9]*',
+        'description': 'How many submissions are expected in this venue? Please provide a number.',
+        'order': 15
+    },
     'Other Important Information': {
         'value-regex': '[\\S\\s]{1,5000}',
         'description': 'Please use this space to clarify any questions above for which you could not use any of the provide options, and to clarify any other information that you think we may need.',
-        'order': 15
+        'order': 16
     },
     'How did you hear about us?': {
         'value-regex': '.*',
         'description': 'Please briefly describe how you heard about OpenReview.',
-        'order': 16
+        'order': 17
     }
 }
 

--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -198,6 +198,9 @@ comment_inv = client.post_invitation(openreview.Invitation(**{
     }
 }))
 
+remove_fields = ['Area Chairs (Metareviewers)', 'Author and Reviewer Anonymity', 'Open Reviewing Policy', 'Public Commentary']
+revision_content = {key: request_content[key] for key in request_content if key not in remove_fields}
+
 revision_inv = client.post_invitation(openreview.Invitation(**{
     'id': 'OpenReview.net/Support/-/Revision',
     'readers': ['everyone'],
@@ -218,7 +221,7 @@ revision_inv = client.post_invitation(openreview.Invitation(**{
         'signatures': {
             'values-regex': '~.*'
         },
-        'content': request_content
+        'content': revision_content
     }
 }))
 

--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -22,24 +22,24 @@ support = openreview.Group(**{
 
 request_content = {
     'title': {
-        'value-copied': '{content[\'Official Conference Name\']}',
-        'description': 'Used for display purposes. Will be copied from the Official Conference Name',
+        'value-copied': '{content[\'Official Venue Name\']}',
+        'description': 'Used for display purposes. Will be copied from the Official Venue Name',
         'order': 1
     },
-    'Official Conference Name': {
-        'description': 'This will appear on your conference\'s OpenReview page. Example: "Seventh International Conference on Learning Representations"',
+    'Official Venue Name': {
+        'description': 'This will appear on your venue\'s OpenReview page. Example: "Seventh International Conference on Learning Representations"',
         'value-regex': '.*',
         'required': True,
         'order': 2
     },
-    'Abbreviated Conference Name': {
-        'description': 'Please include the year as well. This will be used to identify your conference on OpenReview and in email subject lines. Example: "ICLR 2019"',
+    'Abbreviated Venue Name': {
+        'description': 'Please include the year as well. This will be used to identify your venue on OpenReview and in email subject lines. Example: "ICLR 2019"',
         'value-regex': '.*',
         'required': True,
         'order': 3
     },
     'Official Website URL': {
-        'description': 'Please provide the official website URL of the conference.',
+        'description': 'Please provide the official website URL of the venue.',
         'value-regex': '.*',
         'required': True,
         'order': 4
@@ -51,11 +51,10 @@ request_content = {
         'order': 5
     },
     'Area Chairs (Metareviewers)': {
-        'description': 'Does your conference have Area Chairs?',
+        'description': 'Does your venue have Area Chairs?',
         'value-radio': [
-            'Yes, our conference has Area Chairs',
-            'No, our conference does not have Area Chairs',
-            'Other (describe below)'
+            'Yes, our venue has Area Chairs',
+            'No, our venue does not have Area Chairs'
         ],
         'required': True,
         'order': 6
@@ -70,13 +69,13 @@ request_content = {
         'description': 'By when do authors need to submit their manuscripts? Please submit in the following format: YYYY/MM/DD HH:MM(e.g. 2019/01/31 23:59)',
         'order': 8
     },
-    'Conference Start Date': {
-        'description': 'What is the start date of conference itself? Please submit in the following format: YYYY/MM/DD (e.g. 2019/01/31)',
+    'Venue Start Date': {
+        'description': 'What is the start date of venue itself? Please submit in the following format: YYYY/MM/DD (e.g. 2019/01/31)',
         'value-regex': '.*',
         'order': 9
     },
-    'Conference Location': {
-        'description': 'Where the conference is going to be held. For example: Amherst, Massachusetts, United States',
+    'Location': {
+        'description': 'Where the event is being held. For example: Amherst, Massachusetts, United States',
         'value-regex': '.*',
         'order': 10
     },
@@ -87,44 +86,40 @@ request_content = {
             'Reviewer Bid Scores',
             'Reviewer Recommendation Scores',
             'OpenReview Affinity',
-            'TPMS',
-            'Other (describe below)'
+            'TPMS'
         ],
         'order': 11
     },
     'Author and Reviewer Anonymity': {
-        'description': 'What policy best describes your anonymity policy? (Select "Other" if none apply, and describe your request below)',
+        'description': 'What policy best describes your anonymity policy? (If none of the options apply then please describe your request below)',
         'value-radio': [
             'Double-blind',
             'Single-blind (Reviewers are anonymous)',
-            'No anonymity',
-            'Other (describe below)'
+            'No anonymity'
         ],
         'order': 12
     },
     'Open Reviewing Policy': {
         'description': 'Should submitted papers and/or reviews be visible to the public? (This is independent of anonymity policy)',
         'value-radio': [
-            'Submissions and reviews should both be public.',
-            'Submissions should be public, but reviews should be private.',
             'Submissions and reviews should both be private.',
-            'Other (describe below)'
+            'Submissions should be public, but reviews should be private.',
+            'Submissions and reviews should both be public.'
         ],
         'order': 13
     },
     'Public Commentary': {
         'description': 'Would you like to allow members of the public to comment on papers?',
         'value-radio': [
-            'Yes, allow members of the public to comment anonymously.',
-            'Yes, allow members of the public to comment non-anonymously.',
             'No, do not allow public commentary.',
-            'Other (describe below)'
+            'Yes, allow members of the public to comment non-anonymously.',
+            'Yes, allow members of the public to comment anonymously.',
         ],
         'order': 14
     },
     'Other Important Information': {
         'value-regex': '[\\S\\s]{1,5000}',
-        'description': 'Please use this space to clarify any questions above for which you responded "Other", and to clarify any other information that you think we may need.',
+        'description': 'Please use this space to clarify any questions above for which you could not use any of the provide options, and to clarify any other information that you think we may need.',
         'order': 15
     },
     'How did you hear about us?': {

--- a/venues/OpenReview.net/Support/supportRequestsWeb.js
+++ b/venues/OpenReview.net/Support/supportRequestsWeb.js
@@ -10,7 +10,7 @@
 var instructionsHtml = '\
 <h3>Getting Started</h3>\
 <p class="dark">\
-If you would like to use OpenReview for your upcoming Journal, Conference, or Workshop, please fill out and submit the form below. \
+If you would like to use OpenReview for your upcoming venue such as a Journal, Conference, or Workshop, please fill out and submit the form below. \
 Please see the sections below for more details.\
 </p>\
 <h3>Frequently Asked Questions</h3>\
@@ -22,7 +22,7 @@ OpenReview is free, and will remain free for the foreseeable future. \
 <p class="dark">\
 The options provided in the form describe the most common set of variables that are requested. \
 That being said, OpenReview is built for flexibility, and it may be possible for us to accommodate special requests. \
-If you have a special request, please describe it in the text box at the end of the request form. \
+If you have a special request, please describe it in the text area at the end of the request form. \
 We are more likely to honor requests that are useful to many conferences, and that we can incorporate into our regular offerings.\
 </p>\
 <h3>Peer Review Management Options</h3>\

--- a/venues/OpenReview.net/Support/supportRequestsWeb.js
+++ b/venues/OpenReview.net/Support/supportRequestsWeb.js
@@ -23,17 +23,17 @@ OpenReview is free, and will remain free for the foreseeable future. \
 The options provided in the form describe the most common set of variables that are requested. \
 That being said, OpenReview is built for flexibility, and it may be possible for us to accommodate special requests. \
 If you have a special request, please describe it in the text area at the end of the request form. \
-We are more likely to honor requests that are useful to many conferences, and that we can incorporate into our regular offerings.\
+We are more likely to honor requests that are useful to many venues, and that we can incorporate into our regular offerings.\
 </p>\
 <h3>Peer Review Management Options</h3>\
 <p class="dark">\
-OpenReview offers a suite of peer review management tools and features for conference organizers. \
+OpenReview offers a suite of peer review management tools and features for venue organizers. \
 The set of most commonly requested features is listed below, but \
 if you have a specific request, please describe it in the free text field at the end of the form. \
 <ul>\
 <li><strong>Reviewer Recruitment by Email</strong>: OpenReview can deploy custom recruitment emails to potential reviewers and track which have accepted or declined the invitation.</li>\
 <li><strong>Reviewer Bidding for Papers</strong>: OpenReview supports reviewer bidding (i.e. reviewers indicate their preference to review papers).</li>\
-<li><strong>Reviewer Recommendations</strong>: OpenReview supports specific reviewer recommendations by members of the conference (e.g. recommendations made by Area Chairs, Program Chairs, or even other Reviewers).</li>\
+<li><strong>Reviewer Recommendations</strong>: OpenReview supports specific reviewer recommendations by members of the venue (e.g. recommendations made by Area Chairs, Program Chairs, or even other Reviewers).</li>\
 </ul>\
 </p>\
 <h3>The OpenReview Paper Matching System</h3>\
@@ -41,11 +41,11 @@ if you have a specific request, please describe it in the free text field at the
 OpenReview offers automated paper-reviewer assignment optimization and conflict of interest detection, \
 as well as a web interface for browsing, viewing statistics, and modifying the resulting assignments. \
 The OpenReview Matching System supports multiple optimization objectives and arbitrary numerical inputs as features for the match. \
-If you would like to use the OpenReview Paper Matching System for your conference, please indicate which features you would like to use in the form below. \
+If you would like to use the OpenReview Paper Matching System for your venue, please indicate which features you would like to use in the form below. \
 Our most commonly used features are described in the following list: \
 <ul>\
 <li><strong>OpenReview Affinity</strong>: our in-house paper-reviewer affinity model based on TF-IDF vector similarity. </li>\
-<li><strong>TPMS</strong>: <a href="http://torontopapermatching.org/webapp/profileBrowser/about_us/">The Toronto Paper Matching System</a>, a third-party affinity model (if selected, conferences are responsible for coordinating with TPMS)</li>\
+<li><strong>TPMS</strong>: <a href="http://torontopapermatching.org/webapp/profileBrowser/about_us/">The Toronto Paper Matching System</a>, a third-party affinity model (if selected, venues are responsible for coordinating with TPMS)</li>\
 <li><strong>Reviewer Bid Scores</strong>: Reviewers indicate their preference to review papers, which are then converted to scores.</li>\
 <li><strong>Reviewer Recommendation Scores</strong>: Reviewers, Area Chairs, and/or Program Chairs recommend specific reviewers to review papers. These recommendations are then converted to scores according to your specifications.</li>\
 </ul>\
@@ -56,11 +56,11 @@ In terms of the openness of submissions, reviews, and comments, OpenReview offer
 that describe our most commonly requested permissions. We refer to them below as "Public" and "Private." \
 <ul>\
 <li><strong>Public</strong> content is visible to anyone who visits OpenReview.</li> \
-<li><strong>Private</strong> content is visible only to applicable conference officials. For example, \
+<li><strong>Private</strong> content is visible only to applicable venue officials. For example, \
 Private Reviews and Comments are visible only to the Program Chairs, to the Reviewers (and Area Chairs if applicable) assigned to the reviewed paper, \
 and to the paper\'s authors. Private Submissions are visible only to the Program Chairs, all Reviewers, and all Area Chairs.</li>\
 </ul>\
-If you would like a different set of permissions, please describe the permissions in the free text box at the end of the form.\
+If you would like a different set of permissions, please describe the permissions in the text-area at the end of the form.\
 </p>\
 <h3>Questions or Concerns?</h3> \
 <p class="dark">\
@@ -99,7 +99,7 @@ function main() {
 function renderConferenceHeader() {
   Webfield.ui.venueHeader({
     title: "Host a Venue",
-    subtitle: "Submit requests for conference or workshop hosting",
+    subtitle: "Submit requests for hosting a venue (conference, workshop, journal, etc.)",
     location: "Amherst, MA",
     date: "Ongoing",
     website: "https://openreview.net",


### PR DESCRIPTION
1. The word "Conference" has been replaced by "Venue" throughout the request form and the instructions on the page.
2. Once a venue is deployed, a "revision" invitation becomes available to the Program Chairs and to the Support team members. I have removed the fields ['Area Chairs (Metareviewers)', 'Author and Reviewer Anonymity', 'Open Reviewing Policy', 'Public Commentary'] from the revision invitation content thus avoiding the user editing these key venue features.

Please take a look at the language changes on the request form @melisabok @mspector @zbialecki @pmandler 