### PR TITLE
Uai/post decisions

### DIFF
--- a/venues/auai.org/UAI/2019/Conference/python/enable-decisions.py
+++ b/venues/auai.org/UAI/2019/Conference/python/enable-decisions.py
@@ -2,6 +2,7 @@ import argparse
 import openreview
 import datetime
 import config
+import csv
 
 if __name__ == '__main__':
     ## Argument handling
@@ -9,6 +10,7 @@ if __name__ == '__main__':
     parser.add_argument('--baseurl', help="base url")
     parser.add_argument('--username')
     parser.add_argument('--password')
+    parser.add_argument('decisions_file')
     args = parser.parse_args()
 
     client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
@@ -17,4 +19,46 @@ if __name__ == '__main__':
     conference.open_decisions(
         options = ['Accept', 'Reject'],
         start_date = datetime.datetime(2019, 5, 12, 11, 59),
-        due_date = datetime.datetime(2019, 5, 13, 23, 59))
+        due_date = datetime.datetime(2019, 5, 14, 23, 59))
+
+    paper_number_to_decisions = {int(metarev.invitation.split('Paper')[1].split('/')[0]): metarev for metarev in \
+    openreview.tools.iterget_notes(
+        client,
+        invitation = conference.id + '/-/Paper.*/Decision'
+    )}
+    failures = []
+    new_decisions = 0
+    with open(args.decisions_file) as f:
+        for row in csv.reader(f):
+            if row[0] and row[0] != 'Area Chair':
+                paper_number = int(row[1])
+                if paper_number not in paper_number_to_decisions:
+                    decision = row[6].strip()
+                    decision_text = row[7].strip()
+                    if not decision:
+                        if row[5].strip() in ['Accept (Poster)', 'Accept (Oral)']:
+                            decision = 'Accept'
+                        elif row[5].strip() in ['Weak Reject', 'Reject']:
+                            decision = 'Reject'
+                        else:
+                            failures.append(str(paper_number))
+                    else:
+                        print ('Change found for paper {0}, decision: {1} and decision-text:{2}'.format(
+                            paper_number,
+                            decision,
+                            decision_text)
+                        )
+
+                    # post decision note for this paper
+                    decision_note = client.post_note(openreview.Note(
+                        invitation = conference.id + '/-/Paper{0}/Decision'.format(paper_number),
+                        content = {
+                            'title' : 'Final Decision',
+                            'decision' : decision,
+                            'comment' : decision_text
+                        }
+                    ))
+                    new_decisions += 1
+
+    print ('Posted {0} new decisions'.format(new_decisions))
+    print ('Failed to post decisions for ', ', '.join(failures))

--- a/venues/auai.org/UAI/2019/Conference/python/enable-decisions.py
+++ b/venues/auai.org/UAI/2019/Conference/python/enable-decisions.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     new_decisions = 0
     with open(args.decisions_file) as f:
         for row in csv.reader(f):
-            if row[0] and row[0] != 'Area Chair':
+            if len(row) > 0 and row[0] and row[0] != 'Area Chair':
                 paper_number = int(row[1])
                 if paper_number not in paper_number_to_decisions:
                     decision = row[6].strip()


### PR DESCRIPTION
The script expects the input csv to have decisions in the last 2 columns of the first row of a paper.
if no decision is present in the second last column for a paper, the it makes the meta-review recommendation as the decision.
If decision and meta-review both are not present for a paper, the script lists the paper in the end as a failed case.
The script also list the papers for which it finds decisions provided by the Program Chairs.
Sample output:

>>> => python enable-decisions.py UAI2019.csv 
Homepage header set
Change found for paper 19, decision: Reject and decision-text:ABCdEfG
Change found for paper 35, decision: Accept and decision-text:No comments
Change found for paper 78, decision: Accept and decision-text:ABCDefGGH
Posted 351 new decisions
Failed to post decisions (11) for 140, 166, 172, 211, 229, 289, 320, 384, 398, 121, 300