### PR TITLE
fixed sign for revise invitation

### DIFF
--- a/venues/OpenReview.net/Support/supportProcess.js
+++ b/venues/OpenReview.net/Support/supportProcess.js
@@ -41,7 +41,7 @@ function(){
         referent: note.forum,
         forum: note.forum
       },
-      signatures: ['OpenReview.net/Support']
+      signatures: ['OpenReview.net']
     }
 
     var deployInvitation = {


### PR DESCRIPTION
Revisions error out if revision-invitation has OpenReview.net/Support as the signature. 
Error observed: ```error: There was an error in the process function Error: openreview.openreview.OpenReviewException: [{'type': 'forbidden', 'path': 'id', 'value': 'TEST4.com/2019/Conference/-/Submission', 'user': 'OpenReview.net/Support'}]```