### PR TITLE
Use value dict for submission options

### DIFF
--- a/venues/OpenReview.net/Support/init.py
+++ b/venues/OpenReview.net/Support/init.py
@@ -207,7 +207,7 @@ remove_fields = ['Area Chairs (Metareviewers)', 'Author and Reviewer Anonymity',
 revision_content = {key: request_content[key] for key in request_content if key not in remove_fields}
 revision_content['Additional Submission Options'] = {
     'order' : 18,
-    'value-regex': '[\\S\\s]{1,10000}',
+    'value-dict': {},
     'description': 'Configure additional options in the submission form. Valid JSON expected.'
 }
 


### PR DESCRIPTION
Test setup:
- Change the revision invitation to use value-dict instead of value-regex

Tests executed:
- Modify revision invitation (in an existing forum) by changing additional submission options to value-dict. -> Tested Ok, Note that the existing text was present as a string and could be formatted into a JSON.

- Revise an existing forum with additional submission options without making any modifications to the revision invitations. -> Tested Ok, Note that the existing text was present as a string and could be formatted into a JSON.

- Remove additional submission options from an existing venue. -> Tested Ok

- Add an additional submission option to a new forum. -> Tested Ok, but found that the forum page does not render the value-dict fields (refer screenshot below).

![Screen Shot 2019-08-16 at 3 33 00 PM](https://user-images.githubusercontent.com/13500158/63193338-36698800-c03b-11e9-90f3-0a7ad20813f5.png)
![Screen Shot 2019-08-16 at 3 35 10 PM](https://user-images.githubusercontent.com/13500158/63193438-77619c80-c03b-11e9-9e41-c7a439846081.png)


