### PR TITLE
Add paper similarity scripts

### DIFF
--- a/test_venue_scripts/paper_similarity_cross_venue.ipynb
+++ b/test_venue_scripts/paper_similarity_cross_venue.ipynb
@@ -1,0 +1,687 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 0. Log In and Setup\n",
+    "Change credentials and venue details"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openreview\n",
+    "import pandas as pd\n",
+    "\n",
+    "client_v2 = openreview.api.OpenReviewClient(\n",
+    "    baseurl='https://api2.openreview.net',\n",
+    "    username='',\n",
+    "    password=''\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Venue in column 1\n",
+    "venue_A_name = '' # E.g. AAAI26\n",
+    "venue_A_id = ''\n",
+    "\n",
+    "# Venue in column 2\n",
+    "venue_B_name = ''\n",
+    "venue_B_id = ''\n",
+    "\n",
+    "path_to_local_scores_dir = ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1. Request job\n",
+    "Change request as needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_id = client_v2.request_paper_similarity(\n",
+    "    name=f'{venue_A_name}-{venue_B_name}-Paper-Similarity',\n",
+    "    venue_id=f'{venue_A_id}/Submission',\n",
+    "    alternate_venue_id=f'{venue_B_id}/Submission',\n",
+    "    model='specter2+scincl'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1a. Check status\n",
+    "Wait until complete"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = client_v2.get_expertise_status(job_id='')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1b. Find job ID\n",
+    "Get all jobs based on status and find your job based on the name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jobs = client_v2.get_expertise_jobs(status='Complete')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for j in jobs['results']:\n",
+    "    if 'AAAI' in j['name']:\n",
+    "        print(j['jobId'], j['name'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Build similarity score CSV\n",
+    "\n",
+    "- CSV contains: paper IDs, scores, titles, abstracts, author lists, overlapping authors (optional) -- for both venues\n",
+    "-----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Retrieve scores and convert to CSV\n",
+    "Change job_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Could take 5-10min\n",
+    "results = client_v2.get_expertise_results(job_id='')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convert results to CSV\n",
+    "Change CSV name if needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_csv = f'{path_to_local_scores_dir}/{venue_A_name}-{venue_B_name}-Similarity-Scores-Sparse.csv'\n",
+    "pd.DataFrame.from_records(results['results']).to_csv(results_csv, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Read score file, create paper ID matrix, map scores\n",
+    "Change score file name if needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "score_file = results_csv\n",
+    "paper_id_score_matrix = {}\n",
+    "\n",
+    "# Read the results CSV from #2\n",
+    "with open(score_file, 'r') as file:\n",
+    "    csv_reader = csv.reader(file)\n",
+    "    next(csv_reader) # skip header\n",
+    "    for row in csv_reader:\n",
+    "        venue_A_paper_id = row[0]\n",
+    "        venue_B_paper_id = row[1]\n",
+    "        score = float(row[2])\n",
+    "\n",
+    "        # Create matrix, map scores\n",
+    "        if venue_A_paper_id not in paper_id_score_matrix:\n",
+    "            paper_id_score_matrix[venue_A_paper_id] = {}\n",
+    "        \n",
+    "        paper_id_score_matrix[venue_A_paper_id][venue_B_paper_id] = score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Get venue A papers, map paper ID to submission note"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get all submissions\n",
+    "venue_A_subs = client_v2.get_all_notes(invitation=f'{venue_A_id}/-/Submission')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_A_paperid_map = {}\n",
+    "for note in venue_A_subs:\n",
+    "    venue_A_paperid_map[note.id] = note"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Map venue A papers to author profiles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5a. Get all authors, convert to profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_A_all_authors = set()\n",
+    "\n",
+    "for note in venue_A_subs:\n",
+    "    author_list = venue_A_paperid_map[note.id].content['authorids']['value']\n",
+    "    for a in author_list:\n",
+    "        venue_A_all_authors.add(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(venue_A_all_authors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_A_all_author_profiles = openreview.tools.get_profiles(client_v2, venue_A_all_authors)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5b. Map ALL usernames in ALL author profiles to their profile.id\n",
+    "To normalize author IDs to profile IDs\n",
+    "\n",
+    "All IDs should belong to 1 profile.\n",
+    "\n",
+    "- 1 ID may map to multiple profiles -- Merge.\n",
+    "- 1 ID can appear in 1 profile multiple times -- Ignore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "username_to_id = {}\n",
+    "flagged_profiles = []\n",
+    "merge_profiles = []\n",
+    "\n",
+    "for profile in venue_A_all_author_profiles:\n",
+    "    names = [n.get('username', '') for n in profile.content['names']]\n",
+    "    for name in names:\n",
+    "        if name:\n",
+    "            if name in username_to_id:\n",
+    "                flagged_profiles.append(name)\n",
+    "            username_to_id[name] = profile.id\n",
+    "\n",
+    "if flagged_profiles:\n",
+    "    print('Profile anomalies found. Checking...')\n",
+    "    for flagged_id in flagged_profiles:\n",
+    "        profiles = openreview.tools.get_profiles(client_v2, [flagged_id])\n",
+    "        if len(profiles) > 1:\n",
+    "            merge_profiles.append(flagged_id)\n",
+    "\n",
+    "if merge_profiles:\n",
+    "    print(f\"Merge the following profiles before continuing, then re-run script: {merge_profiles}\")\n",
+    "else:\n",
+    "    print('Profiles look good, safe to continue.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5c. Map paper IDs to author profile IDs\n",
+    "If ID is not in map, then profile is probably blocked or deleted. So we keep original author ID from submission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_A_paper_authorids_map = {}\n",
+    "\n",
+    "for note in venue_A_subs:\n",
+    "    author_list = venue_A_paperid_map[note.id].content['authorids']['value']\n",
+    "    \n",
+    "    if note.id not in venue_A_paper_authorids_map:\n",
+    "        venue_A_paper_authorids_map[note.id] = []\n",
+    "    \n",
+    "    for a in author_list:\n",
+    "        if a in username_to_id:\n",
+    "            # Add author profile ID\n",
+    "            venue_A_paper_authorids_map[note.id].append(username_to_id[a])\n",
+    "        else:\n",
+    "            # Add ID from paper if no profile is found\n",
+    "            venue_A_paper_authorids_map[note.id].append(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Get venue B papers, map paper ID to submission note"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get all submissions\n",
+    "venue_B_subs = client_v2.get_all_notes(invitation=f'{venue_B_id}/-/Submission')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(venue_B_subs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_B_paperid_map = {}\n",
+    "for note in venue_B_subs:\n",
+    "    venue_B_paperid_map[note.id] = note"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Map venue B papers to author profiles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7a. Get all authors, convert to profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_B_all_authors = set()\n",
+    "\n",
+    "for note in venue_B_subs:\n",
+    "    author_list = venue_B_paperid_map[note.id].content['authorids']['value']\n",
+    "    for a in author_list:\n",
+    "        venue_B_all_authors.add(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(venue_B_all_authors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_B_all_author_profiles = openreview.tools.get_profiles(client_v2, venue_B_all_authors)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7b. Map ALL usernames in ALL author profiles to their profile.id\n",
+    "To normalize author IDs to profile IDs\n",
+    "\n",
+    "All IDs should belong to 1 profile.\n",
+    "\n",
+    "- 1 ID may map to multiple profiles -- Merge.\n",
+    "- 1 ID can appear in 1 profile multiple times -- Ignore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "username_to_id = {}\n",
+    "flagged_profiles = []\n",
+    "merge_profiles = []\n",
+    "\n",
+    "for profile in venue_B_all_author_profiles:\n",
+    "    names = [n.get('username', '') for n in profile.content['names']]\n",
+    "    for name in names:\n",
+    "        if name:\n",
+    "            if name in username_to_id:\n",
+    "                flagged_profiles.append(name)\n",
+    "            username_to_id[name] = profile.id\n",
+    "\n",
+    "if flagged_profiles:\n",
+    "    print('Profile anomalies found. Checking...')\n",
+    "    for flagged_id in flagged_profiles:\n",
+    "        profiles = openreview.tools.get_profiles(client_v2, [flagged_id])\n",
+    "        if len(profiles) > 1:\n",
+    "            merge_profiles.append(flagged_id)\n",
+    "\n",
+    "if merge_profiles:\n",
+    "    print(f\"Merge the following profiles before continuing, then re-run script: {merge_profiles}\")\n",
+    "else:\n",
+    "    print('Profiles look good, safe to continue.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7c. Map paper IDs to author profile IDs\n",
+    "If ID is not in map, then profile is probably blocked or deleted. So we keep original author ID from submission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_B_paper_authorids_map = {}\n",
+    "\n",
+    "for note in venue_B_subs:\n",
+    "    author_list = venue_B_paperid_map[note.id].content['authorids']['value']\n",
+    "    \n",
+    "    if note.id not in venue_B_paper_authorids_map:\n",
+    "        venue_B_paper_authorids_map[note.id] = []\n",
+    "    \n",
+    "    for a in author_list:\n",
+    "        if a in username_to_id:\n",
+    "            # Add author profile ID\n",
+    "            venue_B_paper_authorids_map[note.id].append(username_to_id[a])\n",
+    "        else:\n",
+    "            # Add ID from paper if no profile is found\n",
+    "            venue_B_paper_authorids_map[note.id].append(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Find overlapping authors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlapping_author_map = {}\n",
+    "\n",
+    "for venue_A_paper_id, venue_B_paper_ids_map in paper_id_score_matrix.items():\n",
+    "    venue_A_paper_author_set = set(venue_A_paper_authorids_map[venue_A_paper_id])\n",
+    "\n",
+    "    for venue_B_paper_id in venue_B_paper_ids_map.keys():\n",
+    "        venue_B_paper_author_set = set(venue_B_paper_authorids_map[venue_B_paper_id])\n",
+    "\n",
+    "        overlapping_authors = venue_A_paper_author_set & venue_B_paper_author_set\n",
+    "\n",
+    "        if overlapping_authors:\n",
+    "            # Key is tuple of both IDs from each venue\n",
+    "            overlapping_author_map[(venue_A_paper_id, venue_B_paper_id)] = overlapping_authors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check how many paper pair combos have overlapping authors\n",
+    "len(overlapping_author_map.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Create final CSV file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 9a. For overlapping authors\n",
+    "Change file name if needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_file_name_overlap = f'{path_to_local_scores_dir}/{venue_A_name}-{venue_B_name}-Paper-Similarity-Sparse-Overlap.csv'\n",
+    "\n",
+    "with open(new_file_name_overlap, 'w', newline='') as csvfile:\n",
+    "    csvwriter = csv.writer(csvfile)\n",
+    "\n",
+    "    csvwriter.writerow([f'{venue_A_name} id', f'{venue_B_name} id', 'Score', 'Matching Authors', f'{venue_A_name} authors', f'{venue_B_name} authors', f'{venue_A_name} title', f'{venue_B_name} title', f'{venue_A_name} abstract', f'{venue_B_name} abstract'])\n",
+    "    \n",
+    "    for paper_pair in overlapping_author_map.keys():\n",
+    "        venue_A_paper_id, venue_B_paper_id = paper_pair\n",
+    "        score = paper_id_score_matrix[venue_A_paper_id][venue_B_paper_id]\n",
+    "\n",
+    "        venue_A_paper_title = venue_A_paperid_map[venue_A_paper_id].content['title']['value']\n",
+    "        venue_B_paper_title = venue_B_paperid_map[venue_B_paper_id].content['title']['value']\n",
+    "\n",
+    "        venue_A_paper_abstract = venue_A_paperid_map[venue_A_paper_id].content['abstract']['value'].replace(\"\\n\", \"\\\\n\")\n",
+    "        venue_B_paper_abstract = venue_B_paperid_map[venue_B_paper_id].content['abstract']['value'].replace(\"\\n\", \"\\\\n\")\n",
+    "\n",
+    "        venue_A_paper_authors = '|'.join(venue_A_paper_authorids_map[venue_A_paper_id])\n",
+    "        venue_B_paper_authors = '|'.join(venue_B_paper_authorids_map[venue_B_paper_id])\n",
+    "\n",
+    "        paper_author_overlap_str = '|'.join(overlapping_author_map[paper_pair])\n",
+    "\n",
+    "        row = [venue_A_paper_id, venue_B_paper_id, score, paper_author_overlap_str, venue_A_paper_authors, venue_B_paper_authors, venue_A_paper_title, venue_B_paper_title, venue_A_paper_abstract, venue_B_paper_abstract]\n",
+    "        \n",
+    "        csvwriter.writerow(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 9b. For non-overlapping authors\n",
+    "Change file name if needed\n",
+    "\n",
+    "Creates a VERY large file, ~70GB if 1 venue is large\n",
+    "\n",
+    "Can take ~15min"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_file_name_no_overlap = f'{path_to_local_scores_dir}/{venue_A_name}-{venue_B_name}-Paper-Similarity-Sparse-No-Overlap.csv'\n",
+    "\n",
+    "with open(new_file_name_no_overlap, 'w', newline='') as csvfile:\n",
+    "    csvwriter = csv.writer(csvfile)\n",
+    "\n",
+    "    csvwriter.writerow([f'{venue_A_name} id', f'{venue_B_name} id', 'Score', 'Matching Authors (if any)', f'{venue_A_name} authors', f'{venue_B_name} authors', f'{venue_A_name} title', f'{venue_B_name} title', f'{venue_A_name} abstract', f'{venue_B_name} abstract'])\n",
+    "    \n",
+    "    for venue_A_paper_id, venue_B_paper_ids_map in paper_id_score_matrix.items():\n",
+    "        venue_A_paper_title = venue_A_paperid_map[venue_A_paper_id].content['title']['value']\n",
+    "        venue_A_paper_abstract = venue_A_paperid_map[venue_A_paper_id].content['abstract']['value'].replace(\"\\n\", \"\\\\n\")\n",
+    "        venue_A_paper_authors = '|'.join(venue_A_paper_authorids_map[venue_A_paper_id])\n",
+    "\n",
+    "        for venue_B_paper_id in venue_B_paper_ids_map.keys():\n",
+    "            score = paper_id_score_matrix[venue_A_paper_id][venue_B_paper_id]\n",
+    "            \n",
+    "            venue_B_paper_title = venue_B_paperid_map[venue_B_paper_id].content['title']['value']\n",
+    "            venue_B_paper_abstract = venue_B_paperid_map[venue_B_paper_id].content['abstract']['value'].replace(\"\\n\", \"\\\\n\")\n",
+    "            venue_B_paper_authors = '|'.join(venue_B_paper_authorids_map[venue_B_paper_id])\n",
+    "\n",
+    "            # Include overlapping authors if they exist, otherwise display \"None\"\n",
+    "            paper_author_overlap = overlapping_author_map.get((venue_A_paper_id, venue_B_paper_id), [])\n",
+    "            paper_author_overlap_str = '|'.join(paper_author_overlap) if paper_author_overlap else 'None'\n",
+    "\n",
+    "            row = [venue_A_paper_id, venue_B_paper_id, score, paper_author_overlap_str, venue_A_paper_authors, venue_B_paper_authors, venue_A_paper_title, venue_B_paper_title, venue_A_paper_abstract, venue_B_paper_abstract]\n",
+    "            \n",
+    "            csvwriter.writerow(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Sort by score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_path = new_file_name_overlap\n",
+    "\n",
+    "# Read CSV\n",
+    "df = pd.read_csv(file_path)\n",
+    "\n",
+    "# Sort by score\n",
+    "df_sorted = df.sort_values(by='Score', ascending=False)\n",
+    "\n",
+    "# Save\n",
+    "df_sorted.to_csv(file_path, index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/test_venue_scripts/paper_similarity_single_venue.ipynb
+++ b/test_venue_scripts/paper_similarity_single_venue.ipynb
@@ -1,0 +1,556 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 0. Log In and Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openreview\n",
+    "import pandas as pd\n",
+    "\n",
+    "client_v2 = openreview.api.OpenReviewClient(\n",
+    "    baseurl='https://api2.openreview.net',\n",
+    "    username='',\n",
+    "    password=''\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "venue_name = '' # E.g. AAAI26\n",
+    "venue_id = ''\n",
+    "\n",
+    "path_to_local_scores_dir = ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1. Request job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_id = client_v2.request_paper_similarity(\n",
+    "    name=f'{venue_name}-Paper-Similarity',\n",
+    "    venue_id=f'{venue_id}/Submission',\n",
+    "    alternate_venue_id=f'{venue_id}/Submission',\n",
+    "    model='specter2+scincl'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1a. Check status\n",
+    "Wait until complete"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = client_v2.get_expertise_status(job_id='')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1b. Find job ID if you lost it\n",
+    "Get all jobs based on status and find your job based on the name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jobs = client_v2.get_expertise_jobs(status='Complete')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for j in jobs['results']:\n",
+    "    if 'AAAI' in j['name']:\n",
+    "        print(j['jobId'], j['name'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Build similarity score CSV\n",
+    "\n",
+    "- CSV contains: paper IDs, scores, titles, abstracts, author lists, overlapping authors (optional) -- for all paper pairs\n",
+    "-----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Retrieve scores and convert to CSV\n",
+    "Change job_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Could take 5-10min\n",
+    "results = client_v2.get_expertise_results(job_id='')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Convert results to CSV\n",
+    "Change CSV name if needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_csv = f'{path_to_local_scores_dir}/{venue_name}-Similarity-Scores-Sparse.csv'\n",
+    "pd.DataFrame.from_records(results['results']).to_csv(results_csv, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Read score file, create paper ID & score matrix\n",
+    "Change score file name if needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "score_file = results_csv\n",
+    "paper_id_score_matrix = {}\n",
+    "\n",
+    "with open(score_file, 'r') as file:\n",
+    "    csv_reader = csv.reader(file)\n",
+    "    next(csv_reader) # skip header\n",
+    "    for row in csv_reader:\n",
+    "        paper_id_1 = row[0]\n",
+    "        paper_id_2 = row[1]\n",
+    "        score = float(row[2])\n",
+    "\n",
+    "        # Create matrix, map scores\n",
+    "        if paper_id_1 not in paper_id_score_matrix:\n",
+    "            paper_id_score_matrix[paper_id_1] = {}\n",
+    "        \n",
+    "        paper_id_score_matrix[paper_id_1][paper_id_2] = score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Get papers, map paper ID to submission note"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get all submissions\n",
+    "subs = client_v2.get_all_notes(invitation=f'{venue_id}/-/Submission')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "paper_id_map = {}\n",
+    "for note in subs:\n",
+    "    paper_id_map[note.id] = note"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Map papers to author profiles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5a. Get all authors, convert to profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_authors = set()\n",
+    "\n",
+    "for note in subs:\n",
+    "    author_list = paper_id_map[note.id].content['authorids']['value']\n",
+    "    for a in author_list:\n",
+    "        all_authors.add(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(all_authors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_author_profiles = openreview.tools.get_profiles(client_v2, all_authors)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5b. Map ALL usernames in ALL author profiles to their profile.id\n",
+    "To normalize author IDs to profile IDs\n",
+    "\n",
+    "All IDs should belong to 1 profile.\n",
+    "\n",
+    "- 1 ID may map to multiple profiles -- Merge.\n",
+    "- 1 ID can appear in 1 profile multiple times -- Ignore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "username_to_id = {}\n",
+    "flagged_profiles = []\n",
+    "merge_profiles = []\n",
+    "\n",
+    "for profile in all_author_profiles:\n",
+    "    names = [n.get('username', '') for n in profile.content['names']]\n",
+    "    for name in names:\n",
+    "        if name:\n",
+    "            if name in username_to_id:\n",
+    "                flagged_profiles.append(name)\n",
+    "            username_to_id[name] = profile.id\n",
+    "\n",
+    "if flagged_profiles:\n",
+    "    print('Profile anomalies found. Checking...')\n",
+    "    for flagged_id in flagged_profiles:\n",
+    "        profiles = openreview.tools.get_profiles(client_v2, [flagged_id])\n",
+    "        if len(profiles) > 1:\n",
+    "            merge_profiles.append(flagged_id)\n",
+    "\n",
+    "if merge_profiles:\n",
+    "    print(f\"Merge the following profiles before continuing, then re-run script: {merge_profiles}\")\n",
+    "else:\n",
+    "    print('Profiles look good, safe to continue.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5c. Map paper IDs to author profile IDs\n",
+    "If ID is not in map, then profile is probably blocked or deleted. So we keep original author ID from submission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "paper_authorids_map = {}\n",
+    "\n",
+    "for note in subs:\n",
+    "    author_list = paper_id_map[note.id].content['authorids']['value']\n",
+    "    \n",
+    "    if note.id not in paper_authorids_map:\n",
+    "        paper_authorids_map[note.id] = []\n",
+    "    \n",
+    "    for a in author_list:\n",
+    "        if a in username_to_id:\n",
+    "            # Add author profile ID\n",
+    "            paper_authorids_map[note.id].append(username_to_id[a])\n",
+    "        else:\n",
+    "            # Add ID from paper if no profile is found\n",
+    "            paper_authorids_map[note.id].append(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Find overlapping authors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlapping_author_map = {}\n",
+    "\n",
+    "for paper_id_1, paper_id_2_map in paper_id_score_matrix.items():\n",
+    "    paper_id_1_author_set = set(paper_authorids_map[paper_id_1])\n",
+    "\n",
+    "    for paper_id_2 in paper_id_2_map.keys():\n",
+    "        paper_id_2_author_set = set(paper_authorids_map[paper_id_2])\n",
+    "\n",
+    "        overlapping_authors = paper_id_1_author_set & paper_id_2_author_set\n",
+    "\n",
+    "        if overlapping_authors:\n",
+    "            # Key is tuple of both IDs from each venue\n",
+    "            overlapping_author_map[(paper_id_1, paper_id_2)] = overlapping_authors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check how many paper pair combos have overlapping authors\n",
+    "len(overlapping_author_map.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Create final CSV file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7a. Set up column names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "col1_name = f'{venue_name}-1'\n",
+    "col2_name = f'{venue_name}-2'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7b. For overlapping authors\n",
+    "Change file name if needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_file_name_overlap = f'{path_to_local_scores_dir}/{venue_name}-Paper-Similarity-Sparse-Overlap.csv'\n",
+    "\n",
+    "with open(new_file_name_overlap, 'w', newline='') as csvfile:\n",
+    "    csvwriter = csv.writer(csvfile)\n",
+    "\n",
+    "    csvwriter.writerow([f'{col1_name} id', f'{col2_name} id', 'Score', 'Matching Authors', f'{col1_name} authors', f'{col2_name} authors', f'{col1_name} title', f'{col2_name} title', f'{col1_name} abstract', f'{col2_name} abstract'])\n",
+    "    \n",
+    "    for paper_pair in overlapping_author_map.keys():\n",
+    "        paper_id_1, paper_id_2 = paper_pair\n",
+    "        score = paper_id_score_matrix[paper_id_1][paper_id_2]\n",
+    "        \n",
+    "        paper_title_1 = paper_id_map[paper_id_1].content['title']['value']\n",
+    "        paper_title_2 = paper_id_map[paper_id_2].content['title']['value']\n",
+    "\n",
+    "        paper_abstract_1 = paper_id_map[paper_id_1].content['abstract']['value'].replace(\"\\n\", \"\\\\n\")\n",
+    "        paper_abstract_2 = paper_id_map[paper_id_2].content['abstract']['value'].replace(\"\\n\", \"\\\\n\")\n",
+    "\n",
+    "        paper_authors_1 = '|'.join(paper_authorids_map[paper_id_1])\n",
+    "        paper_authors_2 = '|'.join(paper_authorids_map[paper_id_2])\n",
+    "\n",
+    "        paper_author_overlap_str = '|'.join(overlapping_author_map[paper_pair])\n",
+    "\n",
+    "        row = [paper_id_1, paper_id_2, score, paper_author_overlap_str, paper_authors_1, paper_authors_2, paper_title_1, paper_title_2, paper_abstract_1, paper_abstract_2]\n",
+    "        \n",
+    "        csvwriter.writerow(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7c. For non-overlapping authors\n",
+    "Change file name if needed\n",
+    "\n",
+    "Creates a VERY large file, ~70GB if 1 venue is large\n",
+    "\n",
+    "Can take ~15min"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_file_name_no_overlap = f'{path_to_local_scores_dir}/{venue_name}-Paper-Similarity-Sparse-No-Overlap.csv'\n",
+    "\n",
+    "with open(new_file_name_no_overlap, 'w', newline='') as csvfile:\n",
+    "    csvwriter = csv.writer(csvfile)\n",
+    "\n",
+    "    csvwriter.writerow([f'{col1_name} id', f'{col2_name} id', 'Score', 'Matching Authors (if any)', f'{col1_name} authors', f'{col2_name} authors', f'{col1_name} title', f'{col2_name} title', f'{col1_name} abstract', f'{col2_name} abstract'])\n",
+    "    \n",
+    "    for paper_id_1, paper_id_2_map in paper_id_score_matrix.items():\n",
+    "        paper_title_1 = paper_id_map[paper_id_1].content['title']['value']\n",
+    "        paper_abstract_1 = paper_id_map[paper_id_1].content['abstract']['value'].replace(\"\\n\", \"\\\\n\")\n",
+    "        paper_authors_1 = '|'.join(paper_authorids_map[paper_id_1])\n",
+    "\n",
+    "        for paper_id_2 in paper_id_2_map.keys():\n",
+    "            score = paper_id_score_matrix[paper_id_1][paper_id_2]\n",
+    "            \n",
+    "            paper_title_2 = paper_id_map[paper_id_2].content['title']['value']\n",
+    "            paper_abstract_2 = paper_id_map[paper_id_2].content['abstract']['value'].replace(\"\\n\", \"\\\\n\")\n",
+    "            paper_authors_2 = '|'.join(paper_authorids_map[paper_id_2])\n",
+    "\n",
+    "            # Include overlapping authors if they exist, otherwise display \"None\"\n",
+    "            paper_author_overlap = overlapping_author_map.get((paper_id_1, paper_id_2), [])\n",
+    "            paper_author_overlap_str = '|'.join(paper_author_overlap) if paper_author_overlap else 'None'\n",
+    "\n",
+    "            row = [paper_id_1, paper_id_2, score, paper_author_overlap_str, paper_authors_1, paper_authors_2, paper_title_1, paper_title_2, paper_abstract_1, paper_abstract_2]\n",
+    "            \n",
+    "            csvwriter.writerow(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Remove dupes and sort\n",
+    "Original score file contains:\n",
+    "- Papers matched with itself: (ID1, ID1, 1.0)\n",
+    "- Paper pair duplicates: (ID1, ID2, 0.45) and (ID2, ID1, 0.45)\n",
+    "    - Same ID comparison, same score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_path = new_file_name_overlap\n",
+    "\n",
+    "# Read CSV\n",
+    "df = pd.read_csv(file_path)\n",
+    "\n",
+    "# 1. Remove self-matches (ID1 == ID2)\n",
+    "df = df[df[f\"{col1_name} id\"] != df[f\"{col2_name} id\"]].copy()\n",
+    "\n",
+    "# 2. Create a normalized pair (order-independent identifier)\n",
+    "df[\"pair\"] = df.apply(\n",
+    "    lambda row: tuple(sorted([row[f\"{col1_name} id\"], row[f\"{col2_name} id\"]])), axis=1\n",
+    ")\n",
+    "\n",
+    "# 3. Remove mirrored duplicates (A,B) vs (B,A), keeping the first\n",
+    "df = df.drop_duplicates(subset=[\"pair\"], keep=\"first\")\n",
+    "\n",
+    "# 4. Clean main df (drop helper column, keep everything else)\n",
+    "df = df.drop(columns=[\"pair\"])\n",
+    "\n",
+    "# 5. Sort by score\n",
+    "df_sorted = df.sort_values(by=\"Score\", ascending=False)\n",
+    "\n",
+    "# 6. Save\n",
+    "df_sorted.to_csv(file_path, index=False)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR shares 2 scripts to compute similarity scores:
- For across 2 venues
- For within the same venue

The final CSV contains paper IDs, author lists, titles, abstracts, and the score.